### PR TITLE
Add SQL schema validation for mhc_allele_restriction table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
-language: java
-script: make test
+language: python
+python:
+  - "3.7"
+install:
+  - pip install -r requirements.txt
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -218,8 +218,12 @@ verify: iedb/mro-iedb.owl $(VERIFY_QUERIES) | build/robot.jar
 	--queries $(VERIFY_QUERIES) \
 	--output-dir build
 
+.PRECIOUS: build/mhc_allele_restriction_errors.tsv
+build/mhc_allele_restriction_errors.tsv: src/validate_mhc_allele_restriction.py iedb/mhc_allele_restriction.tsv | build
+	python3 $^ $@
+
 .PHONY: test
-test: build/report.csv verify
+test: build/report.csv verify build/mhc_allele_restriction_errors.tsv
 
 .PHONY: pytest
 pytest:

--- a/README.md
+++ b/README.md
@@ -51,3 +51,20 @@ With GNU Make and ROBOT installed, building is as simple as running:
 
 	make
 
+### Testing
+
+We use a combination of ROBOT and Python (3.x) scripts for validating the MRO outputs. Install the Python requirements:
+
+	python3 -m pip install -r requirements.txt
+
+Then run:
+	
+	make test
+
+This will run the following checks:
+
+- [ROBOT report](http://robot.obolibrary.org/report) (writes to `build/report.csv` - fails on `ERROR`-level violations)
+- [ROBOT verify](http://robot.obolibrary.org/verify) (writes query results to `build/` - if any queries return results, this is an error)
+- validation of `iedb/mhc_allele_restriction.tsv` table (writes errors to `build/mhc_allele_restriction_errors.tsv`)
+
+The build will fail on any error from these steps.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cerberus
+pandas

--- a/src/validate_mhc_allele_restriction.py
+++ b/src/validate_mhc_allele_restriction.py
@@ -1,0 +1,103 @@
+import csv
+import sys
+import pandas as pd
+
+from argparse import ArgumentParser
+from cerberus import Validator
+
+ALLOWED = "allowed"
+MAX_LEN = "maxlength"
+RE = "regex"
+TYPE = "type"
+NULL = "nullable"
+
+
+def main():
+    p = ArgumentParser()
+    p.add_argument("mhc_allele_restriction")
+    p.add_argument("output")
+    args = p.parse_args()
+
+    schema = {
+        "mhc_allele_restriction_id": {TYPE: "number", NULL: False},
+        "displayed_restriction": {TYPE: "string", MAX_LEN: 85, NULL: False},
+        "synonyms": {TYPE: "string", MAX_LEN: 200, NULL: True},
+        "includes": {TYPE: "string", MAX_LEN: 85, NULL: True},
+        "restriction_level": {
+            TYPE: "string",
+            MAX_LEN: 35,
+            ALLOWED: [
+                "class",
+                "complete molecule",
+                "haplotype",
+                "locus",
+                "partial molecule",
+                "serotype",
+            ],
+            NULL: False,
+        },
+        "organism": {TYPE: "string", MAX_LEN: 150, NULL: False},
+        "organism_ncbi_tax_id": {TYPE: "number", NULL: False},
+        "class": {
+            TYPE: "string",
+            MAX_LEN: 35,
+            ALLOWED: ["I", "II", "non classical"],
+            NULL: False,
+        },
+        "haplotype": {TYPE: "string", MAX_LEN: 10, NULL: True},
+        "locus": {TYPE: "string", MAX_LEN: 10, NULL: True},
+        "serotype": {TYPE: "string", MAX_LEN: 10, NULL: True},
+        "molecule": {TYPE: "string", MAX_LEN: 50, NULL: True},
+        "chain_i_name": {TYPE: "string", MAX_LEN: 35, NULL: True},
+        "chain_ii_name": {TYPE: "string", MAX_LEN: 35, NULL: True},
+        "chain_i_locus": {TYPE: "string", MAX_LEN: 10, NULL: True},
+        "chain_i_mutation": {TYPE: "string", MAX_LEN: 35, NULL: True},
+        "chain_ii_locus": {TYPE: "string", MAX_LEN: 10, NULL: True},
+        "chain_ii_mutation": {TYPE: "string", MAX_LEN: 35, NULL: True},
+        "chain_i_source_id": {TYPE: "number", NULL: True},
+        "chain_ii_source_id": {TYPE: "number", NULL: True},
+        "iri": {
+            TYPE: "string",
+            MAX_LEN: 100,
+            RE: r"^http://purl\.obolibrary\.org/obo/MRO_[0-9]{7}$",
+            NULL: False,
+        },
+    }
+    v = Validator(schema)
+    errs = []
+    df = pd.read_csv(args.mhc_allele_restriction, sep="\t", low_memory=False)
+    df = df.where(pd.notnull(df), None)
+    line = 2
+    for idx, row in df.iterrows():
+        if not v.validate(row.to_dict()):
+            for col_name, msg in v.errors.items():
+                fmt = {
+                    "Line": line,
+                    "Column": col_name,
+                    "Value": row[col_name],
+                    "Message": ", ".join(msg),
+                }
+                errs.append(fmt)
+        line += 1
+
+    with open(args.output, "w") as f:
+        if len(errs) > 0:
+            print(
+                f"{len(errs)} error(s) found in {args.mhc_allele_restriction} - see {args.output}!"
+            )
+            writer = csv.DictWriter(
+                f,
+                delimiter="\t",
+                lineterminator="\n",
+                fieldnames=["Line", "Column", "Value", "Message"],
+            )
+            writer.writeheader()
+            writer.writerows(errs)
+            sys.exit(1)
+        else:
+            print(f"No errors found in {args.mhc_allele_restriction}")
+            f.write("")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Given Jason's SQL schema:
```
 Name                                      Null?    Type
 ----------------------------------------- -------- ----------------------------
 MHC_ALLELE_RESTRICTION_ID                 NOT NULL NUMBER
 DISPLAYED_RESTRICTION                              VARCHAR2(85 CHAR)
 SYNONYMS                                           VARCHAR2(200)
 INCLUDES                                           VARCHAR2(85 CHAR)
 RESTRICTION_LEVEL                                  VARCHAR2(35 CHAR)
 ORGANISM                                           VARCHAR2(150 CHAR)
 ORGANISM_NCBI_TAX_ID                               NUMBER
 CLASS                                              VARCHAR2(35 CHAR)
 HAPLOTYPE                                          VARCHAR2(10 CHAR)
 LOCUS                                              VARCHAR2(10 CHAR)
 SEROTYPE                                           VARCHAR2(10 CHAR)
 MOLECULE                                           VARCHAR2(50 CHAR)
 CHAIN_I_NAME                                       VARCHAR2(35 CHAR)
 CHAIN_II_NAME                                      VARCHAR2(35 CHAR)
 CHAIN_I_LOCUS                                      VARCHAR2(10 CHAR)
 CHAIN_I_MUTATION                                   VARCHAR2(35 CHAR)
 CHAIN_II_LOCUS                                     VARCHAR2(10 CHAR)
 CHAIN_II_MUTATION                                  VARCHAR2(35 CHAR)
 CHAIN_I_SOURCE_ID                                  NUMBER
 CHAIN_II_SOURCE_ID                                 NUMBER
 IRI                                                VARCHAR2(100)
```

Use [`cerberus`](https://docs.python-cerberus.org/en/stable/) to validate the `iedb/mhc_allele_restriction.tsv` file.