### PR TITLE
First pass at VALVE Validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,13 +135,17 @@ apply_%: build/validation_%.tsv | .cogs
 .PHONY: validate_tables
 validate_tables:
 	cogs fetch && cogs pull
+	cogs clear all
 	make apply_errors
+	make apply_valve
 	cogs push
 
 .PHONY: validate_tables_strict
 validate_tables_strict:
 	cogs fetch && cogs pull
+	cogs clear all
 	make apply_errors_strict
+	make apply_valve
 	cogs push
 
 ### Processing

--- a/ontology/core.tsv
+++ b/ontology/core.tsv
@@ -1,6 +1,9 @@
 Label	IEDB Label	Class Type	Parent	Logic	Definition	Definition Source	Example of Usage
 LABEL	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A IAO:0000119	A IAO:0000112
-MHC haplotype		subclass	SO:0001024		A set of MHC alleles that is frequently inherited together.	IEDB	The mouse H-2-k class II haplotype is expressed in C3H mice.
+genetic locus		subclass	genetic entity				
+haplotype		subclass	genetic entity				
+haplotype_block		subclass	genetic entity				
+MHC haplotype		subclass	haplotype		A set of MHC alleles that is frequently inherited together.	IEDB	The mouse H-2-k class II haplotype is expressed in C3H mice.
 MHC ligand assay		subclass	immune epitope assay				
 MHC locus		subclass	genetic locus		The region of a chromosome that codes for MHC molecules.	IEDB	The class II regions encoding for the DP, DQ, and DR molecules on human chromosome 6.
 MHC protein complex with haplotype	haplotype	equivalent	MHC protein complex	('haplotype member of' some 'MHC haplotype')	A protein complex that is a member of an MHC haplotype.	IEDB	The mouse H-2-Kk molecule belongs to the H-2-k haplotype.

--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -1,12 +1,12 @@
 ID	Label	Editor Preferred Term	IEDB Label	Class Type	Parent	Logic	Definition	Definition Source	Example of Usage	Source Ontology
 ID	A rdfs:label	A IAO:0000111	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A IAO:0000119	A IAO:0000112	AI IAO:0000412
-BFO:0000040	material entity									http://purl.obolibrary.org/obo/bfo.owl
+BFO:0000040	material entity	material entity								http://purl.obolibrary.org/obo/bfo.owl
 ECO:0000000	evidence	evidence		subclass	information content entity					http://purl.obolibrary.org/obo/eco.owl
 ECO:0000006	experimental evidence	experimental evidence		subclass	evidence					http://purl.obolibrary.org/obo/eco.owl
-ECO:0000033	author statement supported by traceable reference	author statement supported by traceable reference								http://purl.obolibrary.org/obo/eco.owl
+ECO:0000033	author statement supported by traceable reference									http://purl.obolibrary.org/obo/eco.owl
 GO:0042611	MHC protein complex	MHC protein complex	MHC molecule	equivalent	protein complex	('has part' some (protein and ('gene product of' some 'MHC locus')))	A transmembrane protein complex composed of an MHC alpha chain and, in most cases, either an MHC class II beta chain or an invariant beta2-microglobin chain, and with or without a bound peptide, lipid, or polysaccharide antigen.	GO		http://purl.obolibrary.org/obo/go.owl
 GO:0043234	protein complex	protein complex	MHC	subclass	material entity					http://purl.obolibrary.org/obo/go.owl
-IAO:0000030	information content entity									http://purl.obolibrary.org/obo/iao.owl
+IAO:0000030	information content entity	information content entity								http://purl.obolibrary.org/obo/iao.owl
 NCBITaxon:8355	clawed frog	Xenopus laevis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:8839	duck	Anas platyrhynchos		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:9031	chicken	Gallus gallus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
@@ -28,9 +28,9 @@ NCBITaxon:9940	sheep	Ovis aries		subclass	organism					http://purl.obolibrary.or
 NCBITaxon:9986	rabbit	Oryctolagus cuniculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:10090	mouse	Mus musculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:10116	rat	Rattus norvegicus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-OBI:0100026	organism			subclass	material entity					http://purl.obolibrary.org/obo/obi.owl
-OBI:1110128	immune epitope assay									http://purl.obolibrary.org/obo/obi.owl
-OBI:1110128	assay measuring binding of a T cell epitope:MHC:TCR complex			subclass	immune epitope assay					http://purl.obolibrary.org/obo/obi.owl
+OBI:0100026	organism	organism		subclass	material entity					http://purl.obolibrary.org/obo/obi.owl
+OBI:1110128	immune epitope assay	immune epitope assay								http://purl.obolibrary.org/obo/obi.owl
+OBI:1110037	assay measuring binding of a T cell epitope:MHC:TCR complex	assay measuring binding of a T cell epitope:MHC:TCR complex		subclass	immune epitope assay					http://purl.obolibrary.org/obo/obi.owl
 PR:000000001	protein	protein		subclass	material entity					http://purl.obolibrary.org/obo/pr.owl
 PR:000004580	Beta-2-microglobulin	Beta-2-microglobulin		subclass	protein		A protein that is a translation product of the human B2M gene or a 1:1 ortholog thereof.			http://purl.obolibrary.org/obo/pr.owl
 REO:0000079	genetic locus	genetic locus					a nucleic acid sequence region that is part of a genome and represents a specified location or region on a chromosome or other genomic element.			http://purl.obolibrary.org/obo/reo.owl

--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -1,8 +1,12 @@
 ID	Label	Editor Preferred Term	IEDB Label	Class Type	Parent	Logic	Definition	Definition Source	Example of Usage	Source Ontology
 ID	A rdfs:label	A IAO:0000111	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A IAO:0000119	A IAO:0000112	AI IAO:0000412
+BFO:0000040	material entity									http://purl.obolibrary.org/obo/bfo.owl
 ECO:0000000	evidence	evidence		subclass	information content entity					http://purl.obolibrary.org/obo/eco.owl
+ECO:0000006	experimental evidence	experimental evidence		subclass	evidence					http://purl.obolibrary.org/obo/eco.owl
+ECO:0000033	author statement supported by traceable reference	author statement supported by traceable reference								http://purl.obolibrary.org/obo/eco.owl
 GO:0042611	MHC protein complex	MHC protein complex	MHC molecule	equivalent	protein complex	('has part' some (protein and ('gene product of' some 'MHC locus')))	A transmembrane protein complex composed of an MHC alpha chain and, in most cases, either an MHC class II beta chain or an invariant beta2-microglobin chain, and with or without a bound peptide, lipid, or polysaccharide antigen.	GO		http://purl.obolibrary.org/obo/go.owl
 GO:0043234	protein complex	protein complex	MHC	subclass	material entity					http://purl.obolibrary.org/obo/go.owl
+IAO:0000030	information content entity									http://purl.obolibrary.org/obo/iao.owl
 NCBITaxon:8355	clawed frog	Xenopus laevis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:8839	duck	Anas platyrhynchos		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:9031	chicken	Gallus gallus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
@@ -24,9 +28,12 @@ NCBITaxon:9940	sheep	Ovis aries		subclass	organism					http://purl.obolibrary.or
 NCBITaxon:9986	rabbit	Oryctolagus cuniculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:10090	mouse	Mus musculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:10116	rat	Rattus norvegicus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
+OBI:0100026	organism			subclass	material entity					http://purl.obolibrary.org/obo/obi.owl
+OBI:1110128	immune epitope assay									http://purl.obolibrary.org/obo/obi.owl
+OBI:1110128	assay measuring binding of a T cell epitope:MHC:TCR complex			subclass	immune epitope assay					http://purl.obolibrary.org/obo/obi.owl
 PR:000000001	protein	protein		subclass	material entity					http://purl.obolibrary.org/obo/pr.owl
 PR:000004580	Beta-2-microglobulin	Beta-2-microglobulin		subclass	protein		A protein that is a translation product of the human B2M gene or a 1:1 ortholog thereof.			http://purl.obolibrary.org/obo/pr.owl
-REO:0000079	genetic locus	genetic locus		subclass	genetic entity		a nucleic acid sequence region that is part of a genome and represents a specified location or region on a chromosome or other genomic element.			http://purl.obolibrary.org/obo/reo.owl
-SO:0000355	haplotype_block	haplotype_block		subclass	genetic entity		A region of the genome which is co-inherited as the result of the lack of historic recombination within it.			http://purl.obolibrary.org/obo/so.owl
-SO:0001024	haplotype	haplotype		subclass	genetic entity		A haplotype is one of a set of coexisting sequence variants of a haplotype block.			http://purl.obolibrary.org/obo/so.owl
+REO:0000079	genetic locus	genetic locus					a nucleic acid sequence region that is part of a genome and represents a specified location or region on a chromosome or other genomic element.			http://purl.obolibrary.org/obo/reo.owl
+SO:0000355	haplotype_block	haplotype_block					A region of the genome which is co-inherited as the result of the lack of historic recombination within it.			http://purl.obolibrary.org/obo/so.owl
+SO:0001024	haplotype	haplotype					A haplotype is one of a set of coexisting sequence variants of a haplotype block.			http://purl.obolibrary.org/obo/so.owl
 owl:Thing	owl:Thing									


### PR DESCRIPTION
This still gets a little hung up checking `molecule`, but it takes 45s to validate everything compared to the ~30 minutes that it was taking ROBOT.

The rules were copied from the original ROBOT validation rules. I had to add some imported terms to `external` to be able to reference them without VALVE complaining, and I added some of the external terms to `core` when they have MRO parents (so we don't have to have interdependent tables).