### PR TITLE
2020-11-12 Update

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -145,7 +145,7 @@ BoLA-DQA*003:01 protein complex	148	DQ	300436
 BoLA-DR protein complex	149	DR		
 BoLA-DRB3*001:01 protein complex	150	DRB3		300497
 BoLA-DRB3*030:01 protein complex	151	DRB3		300498
-BoLA-DRB3*4501 protein complex	152	DRB3		300505
+BoLA-DRB3*045:01 protein complex	152	DRB3		300505
 human CD1a protein complex	153	CD1	300486	56585
 human CD1b protein complex	154	CD1	300488	56585
 human CD1c protein complex	155	CD1	300489	56585
@@ -489,7 +489,7 @@ HLA-DPA1*02:01/DPB1*01:01 protein complex	523	DP	300694	300697
 HLA-DQA1*05:05/DQB1*03:01 protein complex	524	DQ	300724	300728
 BoLA-DQA*003:01/DQB*004:02 protein complex	525	DQ	300436	300499
 BoLA-DQA*010:01:01/DQB*010:02:01 protein complex	526	DQ	300437	300501
-BoLA-DQA*012:01:01/DQB*10051 protein complex	527	DQ	300482	300491
+BoLA-DQA*012:01:01/DQB*10:05 protein complex	527	DQ	300482	300491
 BoLA-DQA*022:01/DQB*012:01 protein complex	528	DQ	300483	300514
 BoLA-DQA*2206/DQB*014:02 protein complex	529	DQ		300504
 BoLA-DQA*2206/DQB*013:01 protein complex	530	DQ		300508
@@ -17742,3 +17742,4 @@ HLA-G*01:20 protein complex	17834	G
 HLA-G*01:22 protein complex	17835	G		
 HLA-G*01:23 protein complex	17836	G		
 HLA-G*01:24 protein complex	17837	G		
+Mamu-E*02:11 protein complex	17838	E		

--- a/index.tsv
+++ b/index.tsv
@@ -35799,5 +35799,5 @@ MRO:0035795	SLA-DRA chain	owl:Class
 MRO:0035796	SLA-DRA locus	owl:Class	
 MRO:0035797	SLA-DR protein complex	owl:Class	
 MRO:0035798	SLA-3 protein complex	owl:Class	
-MRO:0035799	Mamu-E*02:11 chain	owl:Class	
-MRO:0035800	Mamu-E*02:11 protein complex	owl:Class	
+MRO:0037011	Mamu-E*02:11 chain	owl:Class	
+MRO:0037012	Mamu-E*02:11 protein complex	owl:Class	

--- a/index.tsv
+++ b/index.tsv
@@ -939,7 +939,7 @@ MRO:0000935	BoLA-DQA*002:02 protein complex	owl:Class
 MRO:0000936	BoLA-DQA*003:01 protein complex	owl:Class	
 MRO:0000937	BoLA-DQA*003:01/DQB*004:02 protein complex	owl:Class	
 MRO:0000938	BoLA-DQA*010:01:01/DQB*010:02:01 protein complex	owl:Class	
-MRO:0000939	BoLA-DQA*012:01:01/DQB*10051 protein complex	owl:Class	
+MRO:0000939	BoLA-DQA*012:01:01/DQB*10:05 protein complex	owl:Class	
 MRO:0000940	BoLA-DQA*022:01/DQB*012:01 protein complex	owl:Class	
 MRO:0000941	BoLA-DQA*022:02:01/DQB*009:01 protein complex	owl:Class	
 MRO:0000942	BoLA-DQA*022:02:01/DQB*013:01 protein complex	owl:Class	
@@ -958,7 +958,7 @@ MRO:0000954	BoLA-DRB3*015:02 protein complex	owl:Class
 MRO:0000955	BoLA-DRB3*020:02 protein complex	owl:Class	
 MRO:0000956	BoLA-DRB3*027:03 protein complex	owl:Class	
 MRO:0000957	BoLA-DRB3*030:01 protein complex	owl:Class	
-MRO:0000958	BoLA-DRB3*4501 protein complex	owl:Class	
+MRO:0000958	BoLA-DRB3*045:01 protein complex	owl:Class	
 MRO:0000959	DLA-88 protein complex	owl:Class	
 MRO:0000960	DLA-88*50801 protein complex	owl:Class	
 MRO:0000961	ELA-N protein complex	owl:Class	
@@ -35799,3 +35799,5 @@ MRO:0035795	SLA-DRA chain	owl:Class
 MRO:0035796	SLA-DRA locus	owl:Class	
 MRO:0035797	SLA-DR protein complex	owl:Class	
 MRO:0035798	SLA-3 protein complex	owl:Class	
+MRO:0035799	Mamu-E*02:11 chain	owl:Class	
+MRO:0035800	Mamu-E*02:11 protein complex	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -17302,6 +17302,7 @@ Mamu-DRB*W6:02 chain		subclass	Mamu-DRB chain
 Mamu-DRB*w2:01 chain		subclass	Mamu-DRB chain	
 Mamu-E chain		equivalent	protein	Mamu-E locus
 Mamu-E*02:04 chain		subclass	Mamu-E chain	
+Mamu-E*02:11 chain		subclass	Mamu-E chain	
 Mamu-MR1 chain		equivalent	protein	Mamu-MR1 locus
 Papa-A chain		equivalent	protein	Papa-A locus
 Papa-A*06:01 chain		subclass	Papa-A chain	

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -28,7 +28,7 @@ BoLA-DQA*003:01/DQB*004:02 protein complex	BoLA-DQA*003:01/DQB*004:02	BoLA-DQA*0
 BoLA-DQA*010:01:01 protein complex	BoLA-DQA*010:01:01	BoLA-DQA*10011	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*010:01:01 chain	BoLA-DQB chain		
 BoLA-DQA*010:01:01/DQB*010:02:01 protein complex	BoLA-DQA*010:01:01/DQB*010:02:01	BoLA-DQA*10011/DQB*10021	complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*010:01:01 chain	BoLA-DQB*010:02:01 chain		
 BoLA-DQA*012:01:01 protein complex	BoLA-DQA*012:01:01	BoLA-DQA*12011	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:01:01 chain	BoLA-DQB chain		
-BoLA-DQA*012:01:01/DQB*10051 protein complex	BoLA-DQA*012:01:01/DQB*10051		complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:01:01 chain	BoLA-DQB*10051 chain		
+BoLA-DQA*012:01:01/DQB*10:05 protein complex	BoLA-DQA*012:01:01/DQB*10051		complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:01:01 chain	BoLA-DQB*10051 chain		
 BoLA-DQA*022:01 protein complex	BoLA-DQA*022:01	BoLA-DQA*2201	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:01 chain	BoLA-DQB chain		
 BoLA-DQA*022:01/DQB*012:01 protein complex	BoLA-DQA*022:01/DQB*012:01	BoLA-DQA*2201/DQB*1201	complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:01 chain	BoLA-DQB*012:01 chain		
 BoLA-DQA*022:02:01 protein complex	BoLA-DQA*022:02:01	BoLA-DQA*2202	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:02:01 chain	BoLA-DQB chain		
@@ -60,7 +60,7 @@ BoLA-DRB3*018:01 protein complex	BoLA-DRB3*018:01	DRB08|BoLA-DRB3*1801	partial m
 BoLA-DRB3*020:02 protein complex	BoLA-DRB3*020:02	BoLA-DRB3*2002	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*020:02 chain		
 BoLA-DRB3*027:03 protein complex	BoLA-DRB3*027:03	BoLA-DRB3*2703	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*027:03 chain		
 BoLA-DRB3*030:01 protein complex	BoLA-DRB3*030:01	BoLA-DRB3*3001	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*030:01 chain		
-BoLA-DRB3*4501 protein complex	BoLA-DRB3*4501		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*4501 chain		
+BoLA-DRB3*045:01 protein complex	BoLA-DRB3*4501		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*4501 chain		
 BoLA-DRB6 protein complex	BoLA-DRB6		locus	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB6 chain		
 Caja-E protein complex	Caja-E		locus	equivalent	MHC class I protein complex	marmoset	Caja-E chain	Beta-2-microglobulin		
 Caja-G protein complex	Caja-G		locus	equivalent	MHC class I protein complex	marmoset	Caja-G chain	Beta-2-microglobulin		
@@ -17385,6 +17385,7 @@ Mamu-DRB*W6:02 protein complex	Mamu-DRB*W6:02	Mamu-DRB6*0102	partial molecule	eq
 Mamu-DRB*w2:01 protein complex	Mamu-DRB*w2:01	Mamu-DRBW2*0101	partial molecule	equivalent	MHC class II protein complex	rhesus macaque	Mamu-DRA chain	Mamu-DRB*w2:01 chain		
 Mamu-E protein complex	Mamu-E		locus	equivalent	MHC class I protein complex	rhesus macaque	Mamu-E chain	Beta-2-microglobulin		
 Mamu-E*02:04 protein complex	Mamu-E*02:04		complete molecule	equivalent	MHC class I protein complex	rhesus macaque	Mamu-E*02:04 chain	Beta-2-microglobulin		
+Mamu-E*02:11 protein complex	Mamu-E*02:11	Mamu-E*0111	complete molecule	equivalent	MHC class I protein complex	rhesus macaque	Mamu-E*02:11 chain	Beta-2-microglobulin		
 Mamu-MR1 protein complex	Mamu-MR1		complete molecule	equivalent	non-classical MHC protein complex	rhesus macaque	Mamu-MR1 chain	Beta-2-microglobulin		
 Papa-A protein complex	Papa-A		locus	equivalent	MHC class I protein complex	bonobo	Papa-A chain	Beta-2-microglobulin		
 Papa-A*06:01 protein complex	Papa-A*06:01	Papa-A06	complete molecule	equivalent	MHC class I protein complex	bonobo	Papa-A*06:01 chain	Beta-2-microglobulin		


### PR DESCRIPTION
This update adds two new terms:
* `MRO:0035799` - Mamu-E*02:11 chain	
* `MRO:0035800` - Mamu-E*02:11 protein complex

This also renames two cow terms:
| ID | Old Label | New Label |
| --- | --- | --- |
| MRO:0000939 | BoLA-DQA\*012:01:01/DQB*10051 | BoLA-DQA\*012:01:01/DQB*10:05 |
| MRO:0000958 | BoLA-DRB3*4501 protein complex | BoLA-DRB3*045:01 protein complex |