### PR TITLE
2020-11-24 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ build/mro-iedb.owl: mro.owl iedb/iedb.tsv iedb/iedb-manual.tsv | build/robot.jar
 build/mhc_allele_restriction.csv: build/mro-iedb.owl src/mhc_allele_restriction.rq | build/robot.jar
 	$(ROBOT) query --input $(word 1,$^) --select $(word 2,$^) $@
 
-build/mhc_allele_restriction.tsv: src/clean.py build/mhc_allele_restriction.csv | iedb
+build/mhc_allele_restriction.tsv: src/clean.py build/mhc_allele_restriction.csv ontology/external.tsv | iedb
 	python3 $^ > $@
 
 build/ALLELE_FINDER_NAMES.csv: build/mro-iedb.owl src/names.rq | build/robot.jar iedb

--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,8 @@ update-seqs: src/update_seqs.py ontology/chain-sequence.tsv build/hla.fasta buil
 	python3 $^
 
 # refresh-seqs will overwrite existing seqs with new seqs
-.PHONY: add-seqs
-add-seqs: src/update_seqs.py ontology/chain-sequence.tsv build/hla.fasta build/mhc.fasta
+.PHONY: refresh-seqs
+refresh-seqs: src/update_seqs.py ontology/chain-sequence.tsv build/hla.fasta build/mhc.fasta
 	python3 $^ -o
 
 build/hla_prot.fasta: | build

--- a/Makefile
+++ b/Makefile
@@ -201,9 +201,15 @@ build/hla.fasta: | build
 build/mhc.fasta: | build
 	wget -O $@ ftp://ftp.ebi.ac.uk/pub/databases/ipd/mhc/MHC_prot.fasta
 
+# update-seqs will only write seqs to terms without seqs
 .PHONY: update-seqs
 update-seqs: src/update_seqs.py ontology/chain-sequence.tsv build/hla.fasta build/mhc.fasta
 	python3 $^
+
+# refresh-seqs will overwrite existing seqs with new seqs
+.PHONY: add-seqs
+add-seqs: src/update_seqs.py ontology/chain-sequence.tsv build/hla.fasta build/mhc.fasta
+	python3 $^ -o
 
 build/hla_prot.fasta: | build
 	curl -o $@ -L https://raw.githubusercontent.com/ANHIG/IMGTHLA/Latest/hla_prot.fasta

--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -18332,3 +18332,5 @@ BoLA-DRB3*060:01 protein complex	18424	DRB3
 BoLA-2*016:01 protein complex	18425	2		
 BoLA-DRB3*020:04 protein complex	18426	DRB3		
 BoLA-DQA*012:04 protein complex	18427	DQ		
+Aime-128 protein complex	18428	128		
+Ctid-UAA protein complex	18429	UAA		

--- a/index.tsv
+++ b/index.tsv
@@ -36986,3 +36986,57 @@ MRO:0036982	evidence of MHC chain expression questionable	owl:Class
 MRO:0036983	evidence of MHC chain expression not observed	owl:Class	
 MRO:0036984	evidence of MHC chain expression observed	owl:Class	
 MRO:0036985	evidence of MHC chain expression observed in >1% of the population	owl:Class	
+MRO:0036986	giant panda MHC class I locus	owl:Class	
+MRO:0036987	giant panda MHC class II locus	owl:Class	
+MRO:0036988	grass carp MHC class I locus	owl:Class	
+MRO:0036989	grass carp MHC class II locus	owl:Class	
+MRO:0036990	Aime-128 locus	owl:Class	
+MRO:0036991	Ctid-UAA locus	owl:Class	
+MRO:0036992	Aime-128 chain	owl:Class	
+MRO:0036993	Ctid-UAA chain	owl:Class	
+MRO:0036994	HLA-A*01:159 chain	owl:Class	
+MRO:0036995	HLA-A*01:281 chain	owl:Class	
+MRO:0036996	HLA-A*02:437 chain	owl:Class	
+MRO:0036997	HLA-A*02:581 chain	owl:Class	
+MRO:0036998	HLA-A*02:728 chain	owl:Class	
+MRO:0036999	HLA-A*02:795 chain	owl:Class	
+MRO:0037000	HLA-A*24:329 chain	owl:Class	
+MRO:0037001	HLA-A*24:378 chain	owl:Class	
+MRO:0037002	HLA-B*18:106 chain	owl:Class	
+MRO:0037003	HLA-B*27:185 chain	owl:Class	
+MRO:0037004	HLA-B*41:56 chain	owl:Class	
+MRO:0037005	HLA-C*04:338 chain	owl:Class	
+MRO:0037006	HLA-C*07:226 chain	owl:Class	
+MRO:0037007	HLA-C*07:432 chain	owl:Class	
+MRO:0037008	HLA-C*07:713 chain	owl:Class	
+MRO:0037009	HLA-C*12:139 chain	owl:Class	
+MRO:0037010	HLA-B*07:44 chain	owl:Class	
+MRO:0037011	HLA-C*03:23 chain	owl:Class	
+MRO:0037012	Aime-128 protein complex	owl:Class	
+MRO:0037013	Ctid-UAA protein complex	owl:Class	
+MRO:0037014	HLA-A*01:159 protein complex	owl:Class	
+MRO:0037015	HLA-A*01:281 protein complex	owl:Class	
+MRO:0037016	HLA-A*02:437 protein complex	owl:Class	
+MRO:0037017	HLA-A*02:581 protein complex	owl:Class	
+MRO:0037018	HLA-A*02:728 protein complex	owl:Class	
+MRO:0037019	HLA-A*02:795 protein complex	owl:Class	
+MRO:0037020	HLA-A*24:329 protein complex	owl:Class	
+MRO:0037021	HLA-A*24:378 protein complex	owl:Class	
+MRO:0037022	HLA-B*18:106 protein complex	owl:Class	
+MRO:0037023	HLA-B*27:185 protein complex	owl:Class	
+MRO:0037024	HLA-B*41:56 protein complex	owl:Class	
+MRO:0037025	HLA-C*04:338 protein complex	owl:Class	
+MRO:0037026	HLA-C*07:226 protein complex	owl:Class	
+MRO:0037027	HLA-C*07:432 protein complex	owl:Class	
+MRO:0037028	HLA-C*07:713 protein complex	owl:Class	
+MRO:0037029	HLA-C*12:139 protein complex	owl:Class	
+MRO:0037030	HLA-B*07:44 protein complex	owl:Class	
+MRO:0037031	HLA-C*03:23 protein complex	owl:Class	
+MRO:0037032	giant panda MHC class I chain	owl:Class	
+MRO:0037033	giant panda MHC class II chain	owl:Class	
+MRO:0037034	grass carp MHC class I chain	owl:Class	
+MRO:0037035	grass carp MHC class II chain	owl:Class	
+MRO:0037036	giant panda MHC class I protein complex	owl:Class	
+MRO:0037037	giant panda MHC class II protein complex	owl:Class	
+MRO:0037038	grass carp MHC class I protein complex	owl:Class	
+MRO:0037039	grass carp MHC class II protein complex	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -1,5 +1,6 @@
 Label	Synonyms	Class Type	Parent	Gene	Expression
-LABEL	A IAO:0000118 SPLIT=|	CLASS_TYPE	C %	C 'gene product of' some %	AI 'has expression evidence' some %
+LABEL	A IAO:0000118 SPLIT=|	CLASS_TYPE	C %	C 'gene product of' some %	AI 'has expression evidence'
+Aime-128 chain		equivalent	protein	Aime-128 locus	
 Anpl-UAA chain		equivalent	protein	Anpl-UAA locus	
 Anpl-UAA*01 chain		subclass	Anpl-UAA chain		
 BoLA-1 chain		equivalent	protein	BoLA-1 locus	
@@ -652,6 +653,7 @@ BoLA-DRB chain		equivalent	protein	BoLA-DRB locus
 BoLA-MR1 chain		equivalent	protein	BoLA-MR1 locus	
 Caja-E chain		equivalent	protein	Caja-E locus	
 Caja-G chain		equivalent	protein	Caja-G locus	
+Ctid-UAA chain		equivalent	protein	Ctid-UAA locus	
 DLA-88 chain		equivalent	protein	DLA-88 locus	
 DLA-88*03401 chain		subclass	DLA-88 chain		
 DLA-88*50101 chain		subclass	DLA-88 chain		
@@ -889,6 +891,7 @@ HLA-A*01:155 chain		subclass	HLA-A chain
 HLA-A*01:156 chain		subclass	HLA-A chain		
 HLA-A*01:157 chain		subclass	HLA-A chain		
 HLA-A*01:158 chain		subclass	HLA-A chain		
+HLA-A*01:159 chain		subclass	HLA-A chain		evidence of MHC chain expression questionable
 HLA-A*01:161 chain		subclass	HLA-A chain		
 HLA-A*01:163 chain		subclass	HLA-A chain		
 HLA-A*01:164 chain		subclass	HLA-A chain		
@@ -997,6 +1000,7 @@ HLA-A*01:277 chain		subclass	HLA-A chain
 HLA-A*01:278 chain		subclass	HLA-A chain		
 HLA-A*01:279 chain		subclass	HLA-A chain		
 HLA-A*01:280 chain		subclass	HLA-A chain		
+HLA-A*01:281 chain		subclass	HLA-A chain		evidence of MHC chain expression questionable
 HLA-A*01:282 chain		subclass	HLA-A chain		
 HLA-A*01:283 chain		subclass	HLA-A chain		
 HLA-A*01:284 chain		subclass	HLA-A chain		
@@ -1460,6 +1464,7 @@ HLA-A*02:433 chain		subclass	HLA-A chain
 HLA-A*02:434 chain		subclass	HLA-A chain		
 HLA-A*02:435 chain		subclass	HLA-A chain		
 HLA-A*02:436 chain		subclass	HLA-A chain		
+HLA-A*02:437 chain		subclass	HLA-A chain		evidence of MHC chain expression questionable
 HLA-A*02:438 chain		subclass	HLA-A chain		
 HLA-A*02:441 chain		subclass	HLA-A chain		
 HLA-A*02:442 chain		subclass	HLA-A chain		
@@ -1592,6 +1597,7 @@ HLA-A*02:577 chain		subclass	HLA-A chain
 HLA-A*02:578 chain		subclass	HLA-A chain		
 HLA-A*02:579 chain		subclass	HLA-A chain		
 HLA-A*02:580 chain		subclass	HLA-A chain		
+HLA-A*02:581 chain		subclass	HLA-A chain		evidence of MHC chain expression questionable
 HLA-A*02:582 chain		subclass	HLA-A chain		
 HLA-A*02:583 chain		subclass	HLA-A chain		
 HLA-A*02:584 chain		subclass	HLA-A chain		
@@ -1727,6 +1733,7 @@ HLA-A*02:724 chain		subclass	HLA-A chain
 HLA-A*02:725 chain		subclass	HLA-A chain		
 HLA-A*02:726 chain		subclass	HLA-A chain		
 HLA-A*02:727 chain		subclass	HLA-A chain		
+HLA-A*02:728 chain		subclass	HLA-A chain		evidence of MHC chain expression questionable
 HLA-A*02:729 chain		subclass	HLA-A chain		
 HLA-A*02:730 chain		subclass	HLA-A chain		
 HLA-A*02:731 chain		subclass	HLA-A chain		
@@ -1784,6 +1791,7 @@ HLA-A*02:786 chain		subclass	HLA-A chain
 HLA-A*02:787 chain		subclass	HLA-A chain		
 HLA-A*02:790 chain		subclass	HLA-A chain		
 HLA-A*02:794 chain		subclass	HLA-A chain		
+HLA-A*02:795 chain		subclass	HLA-A chain		evidence of MHC chain expression questionable
 HLA-A*02:798 chain		subclass	HLA-A chain		
 HLA-A*02:799 chain		subclass	HLA-A chain		
 HLA-A*02:800 chain		subclass	HLA-A chain		
@@ -3004,6 +3012,7 @@ HLA-A*24:325 chain		subclass	HLA-A chain
 HLA-A*24:326 chain		subclass	HLA-A chain		
 HLA-A*24:327 chain		subclass	HLA-A chain		
 HLA-A*24:328 chain		subclass	HLA-A chain		
+HLA-A*24:329 chain		subclass	HLA-A chain		evidence of MHC chain expression questionable
 HLA-A*24:330 chain		subclass	HLA-A chain		
 HLA-A*24:331 chain		subclass	HLA-A chain		
 HLA-A*24:332 chain		subclass	HLA-A chain		
@@ -3049,6 +3058,7 @@ HLA-A*24:374 chain		subclass	HLA-A chain
 HLA-A*24:375 chain		subclass	HLA-A chain		
 HLA-A*24:376 chain		subclass	HLA-A chain		
 HLA-A*24:377 chain		subclass	HLA-A chain		
+HLA-A*24:378 chain		subclass	HLA-A chain		evidence of MHC chain expression questionable
 HLA-A*24:379 chain		subclass	HLA-A chain		
 HLA-A*24:380 chain		subclass	HLA-A chain		
 HLA-A*24:381 chain		subclass	HLA-A chain		
@@ -4602,6 +4612,7 @@ HLA-B*07:40 chain		subclass	HLA-B chain
 HLA-B*07:41 chain		subclass	HLA-B chain		
 HLA-B*07:42 chain		subclass	HLA-B chain		
 HLA-B*07:43 chain		subclass	HLA-B chain		
+HLA-B*07:44 chain		subclass	HLA-B chain		evidence of MHC chain expression not observed
 HLA-B*07:45 chain		subclass	HLA-B chain		
 HLA-B*07:46 chain		subclass	HLA-B chain		
 HLA-B*07:47 chain		subclass	HLA-B chain		
@@ -6031,6 +6042,7 @@ HLA-B*18:102 chain		subclass	HLA-B chain
 HLA-B*18:103 chain		subclass	HLA-B chain		
 HLA-B*18:104 chain		subclass	HLA-B chain		
 HLA-B*18:105 chain		subclass	HLA-B chain		
+HLA-B*18:106 chain		subclass	HLA-B chain		evidence of MHC chain expression questionable
 HLA-B*18:107 chain		subclass	HLA-B chain		
 HLA-B*18:108 chain		subclass	HLA-B chain		
 HLA-B*18:109 chain		subclass	HLA-B chain		
@@ -6294,6 +6306,7 @@ HLA-B*27:181 chain		subclass	HLA-B chain
 HLA-B*27:182 chain		subclass	HLA-B chain		
 HLA-B*27:183 chain		subclass	HLA-B chain		
 HLA-B*27:184 chain		subclass	HLA-B chain		
+HLA-B*27:185 chain		subclass	HLA-B chain		evidence of MHC chain expression questionable
 HLA-B*27:186 chain		subclass	HLA-B chain		
 HLA-B*27:187 chain		subclass	HLA-B chain		
 HLA-B*27:188 chain		subclass	HLA-B chain		
@@ -7630,6 +7643,7 @@ HLA-B*41:52 chain		subclass	HLA-B chain
 HLA-B*41:53 chain		subclass	HLA-B chain		
 HLA-B*41:54 chain		subclass	HLA-B chain		
 HLA-B*41:55 chain		subclass	HLA-B chain		
+HLA-B*41:56 chain		subclass	HLA-B chain		evidence of MHC chain expression questionable
 HLA-B*41:57 chain		subclass	HLA-B chain		
 HLA-B*41:58 chain		subclass	HLA-B chain		
 HLA-B*41:59 chain		subclass	HLA-B chain		
@@ -9659,6 +9673,7 @@ HLA-C*03:17 chain		subclass	HLA-C chain
 HLA-C*03:18 chain		subclass	HLA-C chain		
 HLA-C*03:19 chain		subclass	HLA-C chain		
 HLA-C*03:21 chain		subclass	HLA-C chain		
+HLA-C*03:23 chain		subclass	HLA-C chain		evidence of MHC chain expression not observed
 HLA-C*03:24 chain		subclass	HLA-C chain		
 HLA-C*03:25 chain		subclass	HLA-C chain		
 HLA-C*03:26 chain		subclass	HLA-C chain		
@@ -10436,6 +10451,7 @@ HLA-C*04:334 chain		subclass	HLA-C chain
 HLA-C*04:335 chain		subclass	HLA-C chain		
 HLA-C*04:336 chain		subclass	HLA-C chain		
 HLA-C*04:337 chain		subclass	HLA-C chain		
+HLA-C*04:338 chain		subclass	HLA-C chain		evidence of MHC chain expression questionable
 HLA-C*04:339 chain		subclass	HLA-C chain		
 HLA-C*04:340 chain		subclass	HLA-C chain		
 HLA-C*04:341 chain		subclass	HLA-C chain		
@@ -11225,6 +11241,7 @@ HLA-C*07:222 chain		subclass	HLA-C chain
 HLA-C*07:223 chain		subclass	HLA-C chain		
 HLA-C*07:224 chain		subclass	HLA-C chain		
 HLA-C*07:225 chain		subclass	HLA-C chain		
+HLA-C*07:226 chain		subclass	HLA-C chain		evidence of MHC chain expression questionable
 HLA-C*07:228 chain		subclass	HLA-C chain		
 HLA-C*07:229 chain		subclass	HLA-C chain		
 HLA-C*07:230 chain		subclass	HLA-C chain		
@@ -11422,6 +11439,7 @@ HLA-C*07:428 chain		subclass	HLA-C chain
 HLA-C*07:429 chain		subclass	HLA-C chain		
 HLA-C*07:430 chain		subclass	HLA-C chain		
 HLA-C*07:431 chain		subclass	HLA-C chain		
+HLA-C*07:432 chain		subclass	HLA-C chain		evidence of MHC chain expression questionable
 HLA-C*07:433 chain		subclass	HLA-C chain		
 HLA-C*07:434 chain		subclass	HLA-C chain		
 HLA-C*07:435 chain		subclass	HLA-C chain		
@@ -11680,6 +11698,7 @@ HLA-C*07:709 chain		subclass	HLA-C chain
 HLA-C*07:710 chain		subclass	HLA-C chain		
 HLA-C*07:711 chain		subclass	HLA-C chain		
 HLA-C*07:712 chain		subclass	HLA-C chain		
+HLA-C*07:713 chain		subclass	HLA-C chain		evidence of MHC chain expression questionable
 HLA-C*07:714 chain		subclass	HLA-C chain		
 HLA-C*07:715 chain		subclass	HLA-C chain		
 HLA-C*07:716 chain		subclass	HLA-C chain		
@@ -12143,6 +12162,7 @@ HLA-C*12:135 chain		subclass	HLA-C chain
 HLA-C*12:136 chain		subclass	HLA-C chain		
 HLA-C*12:137 chain		subclass	HLA-C chain		
 HLA-C*12:138 chain		subclass	HLA-C chain		
+HLA-C*12:139 chain		subclass	HLA-C chain		evidence of MHC chain expression questionable
 HLA-C*12:140 chain		subclass	HLA-C chain		
 HLA-C*12:141 chain		subclass	HLA-C chain		
 HLA-C*12:142 chain		subclass	HLA-C chain		
@@ -18035,8 +18055,12 @@ crab-eating macaque MHC class II chain		equivalent	protein	crab-eating macaque M
 dog MHC class I chain		equivalent	protein	dog MHC class I locus	
 dog MHC class II chain		equivalent	protein	dog MHC class II locus	
 duck MHC class I chain		equivalent	protein	duck MHC class I locus	
+giant panda MHC class I chain		equivalent	protein	giant panda MHC class I locus	
+giant panda MHC class II chain		equivalent	protein	giant panda MHC class II locus	
 gorilla MHC class I chain		equivalent	protein	gorilla MHC class I locus	
 gorilla MHC class II chain		equivalent	protein	gorilla MHC class II locus	
+grass carp MHC class I chain		equivalent	protein	grass carp MHC class I locus	
+grass carp MHC class II chain		equivalent	protein	grass carp MHC class II locus	
 horse MHC class I chain		equivalent	protein	horse MHC class I locus	
 horse MHC class II chain		equivalent	protein	horse MHC class II locus	
 human BTN3A1 chain		subclass	HLA-BTN3A chain		

--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -3,6 +3,7 @@ ID	A rdfs:label	A IAO:0000111	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A I
 ECO:0000000	evidence	evidence		subclass	information content entity					http://purl.obolibrary.org/obo/eco.owl
 GO:0042611	MHC protein complex	MHC protein complex	MHC molecule	equivalent	protein complex	('has part' some (protein and ('gene product of' some 'MHC locus')))	A transmembrane protein complex composed of an MHC alpha chain and, in most cases, either an MHC class II beta chain or an invariant beta2-microglobin chain, and with or without a bound peptide, lipid, or polysaccharide antigen.	GO		http://purl.obolibrary.org/obo/go.owl
 GO:0043234	protein complex	protein complex	MHC	subclass	material entity					http://purl.obolibrary.org/obo/go.owl
+NCBITaxon:7959	grass carp	Ctenopharyngodon idella		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:8355	clawed frog	Xenopus laevis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:8839	duck	Anas platyrhynchos		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:9031	chicken	Gallus gallus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
@@ -16,6 +17,7 @@ NCBITaxon:9597	bonobo	Pan paniscus		subclass	organism					http://purl.obolibrary
 NCBITaxon:9598	chimpanzee	Pan troglodytes		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:9606	human	Homo sapiens		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:9615	dog	Canis lupus familiaris		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
+NCBITaxon:9646	giant panda	Ailuropoda melanoleuca		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:9685	cat	Felis catus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:9796	horse	Equus caballus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
 NCBITaxon:9823	pig	Sus scrofa		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl

--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -1,34 +1,34 @@
-ID	Label	Editor Preferred Term	IEDB Label	Class Type	Parent	Logic	Definition	Definition Source	Example of Usage	Source Ontology
-ID	A rdfs:label	A IAO:0000111	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A IAO:0000119	A IAO:0000112	AI IAO:0000412
-ECO:0000000	evidence	evidence		subclass	information content entity					http://purl.obolibrary.org/obo/eco.owl
-GO:0042611	MHC protein complex	MHC protein complex	MHC molecule	equivalent	protein complex	('has part' some (protein and ('gene product of' some 'MHC locus')))	A transmembrane protein complex composed of an MHC alpha chain and, in most cases, either an MHC class II beta chain or an invariant beta2-microglobin chain, and with or without a bound peptide, lipid, or polysaccharide antigen.	GO		http://purl.obolibrary.org/obo/go.owl
-GO:0043234	protein complex	protein complex	MHC	subclass	material entity					http://purl.obolibrary.org/obo/go.owl
-NCBITaxon:7959	grass carp	Ctenopharyngodon idella		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:8355	clawed frog	Xenopus laevis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:8839	duck	Anas platyrhynchos		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9031	chicken	Gallus gallus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9402	black flying fox	Pteropus alecto		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9483	marmoset	Callithrix jacchus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9490	cotton-top tamarin	Saguinus oedipus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9541	crab-eating macaque	Macaca fascicularis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9544	rhesus macaque	Macaca mulatta		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9593	gorilla	Gorilla gorilla		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9597	bonobo	Pan paniscus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9598	chimpanzee	Pan troglodytes		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9606	human	Homo sapiens		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9615	dog	Canis lupus familiaris		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9646	giant panda	Ailuropoda melanoleuca		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9685	cat	Felis catus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9796	horse	Equus caballus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9823	pig	Sus scrofa		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9913	cattle	Bos taurus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9940	sheep	Ovis aries		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:9986	rabbit	Oryctolagus cuniculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:10090	mouse	Mus musculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-NCBITaxon:10116	rat	Rattus norvegicus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl
-PR:000000001	protein	protein		subclass	material entity					http://purl.obolibrary.org/obo/pr.owl
-PR:000004580	Beta-2-microglobulin	Beta-2-microglobulin		subclass	protein		A protein that is a translation product of the human B2M gene or a 1:1 ortholog thereof.			http://purl.obolibrary.org/obo/pr.owl
-REO:0000079	genetic locus	genetic locus		subclass	genetic entity		a nucleic acid sequence region that is part of a genome and represents a specified location or region on a chromosome or other genomic element.			http://purl.obolibrary.org/obo/reo.owl
-SO:0000355	haplotype_block	haplotype_block		subclass	genetic entity		A region of the genome which is co-inherited as the result of the lack of historic recombination within it.			http://purl.obolibrary.org/obo/so.owl
-SO:0001024	haplotype	haplotype		subclass	genetic entity		A haplotype is one of a set of coexisting sequence variants of a haplotype block.			http://purl.obolibrary.org/obo/so.owl
-owl:Thing	owl:Thing									
+ID	Label	Editor Preferred Term	IEDB Label	Class Type	Parent	Logic	Definition	Definition Source	Example of Usage	Source Ontology	Species Code
+ID	A rdfs:label	A IAO:0000111	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A IAO:0000119	A IAO:0000112	AI IAO:0000412	
+ECO:0000000	evidence	evidence		subclass	information content entity					http://purl.obolibrary.org/obo/eco.owl	
+GO:0042611	MHC protein complex	MHC protein complex	MHC molecule	equivalent	protein complex	('has part' some (protein and ('gene product of' some 'MHC locus')))	A transmembrane protein complex composed of an MHC alpha chain and, in most cases, either an MHC class II beta chain or an invariant beta2-microglobin chain, and with or without a bound peptide, lipid, or polysaccharide antigen.	GO		http://purl.obolibrary.org/obo/go.owl	
+GO:0043234	protein complex	protein complex	MHC	subclass	material entity					http://purl.obolibrary.org/obo/go.owl	
+NCBITaxon:7959	grass carp	Ctenopharyngodon idella		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ctid
+NCBITaxon:8355	clawed frog	Xenopus laevis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Xela
+NCBITaxon:8839	duck	Anas platyrhynchos		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Anpl
+NCBITaxon:9031	chicken	Gallus gallus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Gaga
+NCBITaxon:9402	black flying fox	Pteropus alecto		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ptal
+NCBITaxon:9483	marmoset	Callithrix jacchus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Caja
+NCBITaxon:9490	cotton-top tamarin	Saguinus oedipus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Saoe
+NCBITaxon:9541	crab-eating macaque	Macaca fascicularis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Mafa
+NCBITaxon:9544	rhesus macaque	Macaca mulatta		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Mamu
+NCBITaxon:9593	gorilla	Gorilla gorilla		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Gogo
+NCBITaxon:9597	bonobo	Pan paniscus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Papa
+NCBITaxon:9598	chimpanzee	Pan troglodytes		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Patr
+NCBITaxon:9606	human	Homo sapiens		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	HLA
+NCBITaxon:9615	dog	Canis lupus familiaris		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	DLA
+NCBITaxon:9646	giant panda	Ailuropoda melanoleuca		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Amie
+NCBITaxon:9685	cat	Felis catus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	FLA
+NCBITaxon:9796	horse	Equus caballus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	ELA
+NCBITaxon:9823	pig	Sus scrofa		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	SLA
+NCBITaxon:9913	cattle	Bos taurus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	BoLA
+NCBITaxon:9940	sheep	Ovis aries		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ovar
+NCBITaxon:9986	rabbit	Oryctolagus cuniculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	RLA
+NCBITaxon:10090	mouse	Mus musculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	H2
+NCBITaxon:10116	rat	Rattus norvegicus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	RT1
+PR:000000001	protein	protein		subclass	material entity					http://purl.obolibrary.org/obo/pr.owl	
+PR:000004580	Beta-2-microglobulin	Beta-2-microglobulin		subclass	protein		A protein that is a translation product of the human B2M gene or a 1:1 ortholog thereof.			http://purl.obolibrary.org/obo/pr.owl	
+REO:0000079	genetic locus	genetic locus		subclass	genetic entity		a nucleic acid sequence region that is part of a genome and represents a specified location or region on a chromosome or other genomic element.			http://purl.obolibrary.org/obo/reo.owl	
+SO:0000355	haplotype_block	haplotype_block		subclass	genetic entity		A region of the genome which is co-inherited as the result of the lack of historic recombination within it.			http://purl.obolibrary.org/obo/so.owl	
+SO:0001024	haplotype	haplotype		subclass	genetic entity		A haplotype is one of a set of coexisting sequence variants of a haplotype block.			http://purl.obolibrary.org/obo/so.owl	
+owl:Thing	owl:Thing										

--- a/ontology/genetic-locus.tsv
+++ b/ontology/genetic-locus.tsv
@@ -1,5 +1,6 @@
 Label	Synonyms	Class Type	Parent	In Taxon
 LABEL	A IAO:0000118 SPLIT=|	CLASS_TYPE	C %	C 'in taxon' some %
+Aime-128 locus		subclass	giant panda MHC class I locus	
 Anpl-UAA locus		subclass	duck MHC class I locus	
 BoLA-1 locus		subclass	cattle MHC class I locus	
 BoLA-2 locus		subclass	cattle MHC class I locus	
@@ -16,6 +17,7 @@ BoLA-DRB locus		subclass	cattle MHC class II locus
 BoLA-MR1 locus		subclass	cattle non-classical MHC locus	
 Caja-E locus		subclass	marmoset MHC class I locus	
 Caja-G locus		subclass	marmoset MHC class I locus	
+Ctid-UAA locus		subclass	grass carp MHC class I locus	
 DLA-88 locus		subclass	dog MHC class I locus	
 ELA-1 locus		subclass	horse MHC class I locus	
 ELA-16 locus		subclass	horse MHC class I locus	
@@ -122,8 +124,12 @@ crab-eating macaque MHC class II locus		subclass	MHC class II locus	crab-eating 
 dog MHC class I locus		subclass	MHC class I locus	dog
 dog MHC class II locus		subclass	MHC class II locus	dog
 duck MHC class I locus		subclass	MHC class I locus	duck
+giant panda MHC class I locus		subclass	MHC class I locus	giant panda
+giant panda MHC class II locus		subclass	MHC class II locus	giant panda
 gorilla MHC class I locus		subclass	MHC class I locus	gorilla
 gorilla MHC class II locus		subclass	MHC class II locus	gorilla
+grass carp MHC class I locus		subclass	MHC class I locus	grass carp
+grass carp MHC class II locus		subclass	MHC class II locus	grass carp
 horse MHC class I locus		subclass	MHC class I locus	horse
 horse MHC class II locus		subclass	MHC class II locus	horse
 human MHC class I locus		subclass	MHC class I locus	human

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -1,5 +1,6 @@
 Label	IEDB Label	Synonyms	Restriction Level	Class Type	Parent	In Taxon	Alpha Chain	Beta Chain	With Haplotype	With Serotype
 LABEL	A OBI:9991118	A IAO:0000118 SPLIT=|	A has MHC restriction level	CLASS_TYPE	C %	C 'in taxon' some %	C 'has part' some %	C 'has part' some %	C 'haplotype member of' some %	C 'serotype member of' some %
+Aime-128 protein complex	Aime-128		locus	equivalent	MHC class I protein complex	giant panda	Aime-128 chain	Beta-2-microglobulin		
 Anpl-UAA protein complex	Anpl-UAA		locus	equivalent	MHC class I protein complex	duck	Anpl-UAA chain	Beta-2-microglobulin		
 Anpl-UAA*01 protein complex	Anpl-UAA*01		complete molecule	equivalent	MHC class I protein complex	duck	Anpl-UAA*01 chain	Beta-2-microglobulin		
 BoLA-1 protein complex	BoLA-1		locus	equivalent	MHC class I protein complex	cattle	BoLA-1 chain	Beta-2-microglobulin		
@@ -654,6 +655,7 @@ BoLA-DRB3*163:01 protein complex	BoLA-DRB3*163:01		partial molecule	equivalent	M
 BoLA-DRB6 protein complex	BoLA-DRB6		locus	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB6 chain		
 Caja-E protein complex	Caja-E		locus	equivalent	MHC class I protein complex	marmoset	Caja-E chain	Beta-2-microglobulin		
 Caja-G protein complex	Caja-G		locus	equivalent	MHC class I protein complex	marmoset	Caja-G chain	Beta-2-microglobulin		
+Ctid-UAA protein complex	Ctid-UAA		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	Beta-2-microglobulin		
 DLA-88 protein complex	DLA-88		locus	equivalent	MHC class I protein complex	dog	DLA-88 chain	Beta-2-microglobulin		
 DLA-88*03401 protein complex	DLA-88*03401		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*03401 chain	Beta-2-microglobulin		
 DLA-88*50101 protein complex	DLA-88*50101		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*50101 chain	Beta-2-microglobulin		
@@ -866,6 +868,7 @@ HLA-A*01:155 protein complex	HLA-A*01:155		complete molecule	equivalent	MHC clas
 HLA-A*01:156 protein complex	HLA-A*01:156		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:156 chain	Beta-2-microglobulin		
 HLA-A*01:157 protein complex	HLA-A*01:157		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:157 chain	Beta-2-microglobulin		
 HLA-A*01:158 protein complex	HLA-A*01:158		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:158 chain	Beta-2-microglobulin		
+HLA-A*01:159 protein complex	HLA-A*01:159		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:159 chain	Beta-2-microglobulin		
 HLA-A*01:161 protein complex	HLA-A*01:161		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:161 chain	Beta-2-microglobulin		
 HLA-A*01:163 protein complex	HLA-A*01:163		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:163 chain	Beta-2-microglobulin		
 HLA-A*01:164 protein complex	HLA-A*01:164		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:164 chain	Beta-2-microglobulin		
@@ -974,6 +977,7 @@ HLA-A*01:277 protein complex	HLA-A*01:277		complete molecule	equivalent	MHC clas
 HLA-A*01:278 protein complex	HLA-A*01:278		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:278 chain	Beta-2-microglobulin		
 HLA-A*01:279 protein complex	HLA-A*01:279		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:279 chain	Beta-2-microglobulin		
 HLA-A*01:280 protein complex	HLA-A*01:280		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:280 chain	Beta-2-microglobulin		
+HLA-A*01:281 protein complex	HLA-A*01:281		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:281 chain	Beta-2-microglobulin		
 HLA-A*01:282 protein complex	HLA-A*01:282		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:282 chain	Beta-2-microglobulin		
 HLA-A*01:283 protein complex	HLA-A*01:283		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:283 chain	Beta-2-microglobulin		
 HLA-A*01:284 protein complex	HLA-A*01:284		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*01:284 chain	Beta-2-microglobulin		
@@ -1437,6 +1441,7 @@ HLA-A*02:433 protein complex	HLA-A*02:433		complete molecule	equivalent	MHC clas
 HLA-A*02:434 protein complex	HLA-A*02:434		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:434 chain	Beta-2-microglobulin		
 HLA-A*02:435 protein complex	HLA-A*02:435		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:435 chain	Beta-2-microglobulin		
 HLA-A*02:436 protein complex	HLA-A*02:436		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:436 chain	Beta-2-microglobulin		
+HLA-A*02:437 protein complex	HLA-A*02:437		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:437 chain	Beta-2-microglobulin		
 HLA-A*02:438 protein complex	HLA-A*02:438		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:438 chain	Beta-2-microglobulin		
 HLA-A*02:441 protein complex	HLA-A*02:441		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:441 chain	Beta-2-microglobulin		
 HLA-A*02:442 protein complex	HLA-A*02:442		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:442 chain	Beta-2-microglobulin		
@@ -1569,6 +1574,7 @@ HLA-A*02:577 protein complex	HLA-A*02:577		complete molecule	equivalent	MHC clas
 HLA-A*02:578 protein complex	HLA-A*02:578		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:578 chain	Beta-2-microglobulin		
 HLA-A*02:579 protein complex	HLA-A*02:579		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:579 chain	Beta-2-microglobulin		
 HLA-A*02:580 protein complex	HLA-A*02:580		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:580 chain	Beta-2-microglobulin		
+HLA-A*02:581 protein complex	HLA-A*02:581		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:581 chain	Beta-2-microglobulin		
 HLA-A*02:582 protein complex	HLA-A*02:582		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:582 chain	Beta-2-microglobulin		
 HLA-A*02:583 protein complex	HLA-A*02:583		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:583 chain	Beta-2-microglobulin		
 HLA-A*02:584 protein complex	HLA-A*02:584		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:584 chain	Beta-2-microglobulin		
@@ -1704,6 +1710,7 @@ HLA-A*02:724 protein complex	HLA-A*02:724		complete molecule	equivalent	MHC clas
 HLA-A*02:725 protein complex	HLA-A*02:725		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:725 chain	Beta-2-microglobulin		
 HLA-A*02:726 protein complex	HLA-A*02:726		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:726 chain	Beta-2-microglobulin		
 HLA-A*02:727 protein complex	HLA-A*02:727		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:727 chain	Beta-2-microglobulin		
+HLA-A*02:728 protein complex	HLA-A*02:728		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:728 chain	Beta-2-microglobulin		
 HLA-A*02:729 protein complex	HLA-A*02:729		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:729 chain	Beta-2-microglobulin		
 HLA-A*02:730 protein complex	HLA-A*02:730		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:730 chain	Beta-2-microglobulin		
 HLA-A*02:731 protein complex	HLA-A*02:731		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:731 chain	Beta-2-microglobulin		
@@ -1761,6 +1768,7 @@ HLA-A*02:786 protein complex	HLA-A*02:786		complete molecule	equivalent	MHC clas
 HLA-A*02:787 protein complex	HLA-A*02:787		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:787 chain	Beta-2-microglobulin		
 HLA-A*02:790 protein complex	HLA-A*02:790		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:790 chain	Beta-2-microglobulin		
 HLA-A*02:794 protein complex	HLA-A*02:794		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:794 chain	Beta-2-microglobulin		
+HLA-A*02:795 protein complex	HLA-A*02:795		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:795 chain	Beta-2-microglobulin		
 HLA-A*02:798 protein complex	HLA-A*02:798		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:798 chain	Beta-2-microglobulin		
 HLA-A*02:799 protein complex	HLA-A*02:799		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:799 chain	Beta-2-microglobulin		
 HLA-A*02:800 protein complex	HLA-A*02:800		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*02:800 chain	Beta-2-microglobulin		
@@ -2981,6 +2989,7 @@ HLA-A*24:325 protein complex	HLA-A*24:325		complete molecule	equivalent	MHC clas
 HLA-A*24:326 protein complex	HLA-A*24:326		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:326 chain	Beta-2-microglobulin		
 HLA-A*24:327 protein complex	HLA-A*24:327		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:327 chain	Beta-2-microglobulin		
 HLA-A*24:328 protein complex	HLA-A*24:328		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:328 chain	Beta-2-microglobulin		
+HLA-A*24:329 protein complex	HLA-A*24:329		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:329 chain	Beta-2-microglobulin		
 HLA-A*24:330 protein complex	HLA-A*24:330		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:330 chain	Beta-2-microglobulin		
 HLA-A*24:331 protein complex	HLA-A*24:331		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:331 chain	Beta-2-microglobulin		
 HLA-A*24:332 protein complex	HLA-A*24:332		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:332 chain	Beta-2-microglobulin		
@@ -3026,6 +3035,7 @@ HLA-A*24:374 protein complex	HLA-A*24:374		complete molecule	equivalent	MHC clas
 HLA-A*24:375 protein complex	HLA-A*24:375		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:375 chain	Beta-2-microglobulin		
 HLA-A*24:376 protein complex	HLA-A*24:376		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:376 chain	Beta-2-microglobulin		
 HLA-A*24:377 protein complex	HLA-A*24:377		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:377 chain	Beta-2-microglobulin		
+HLA-A*24:378 protein complex	HLA-A*24:378		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:378 chain	Beta-2-microglobulin		
 HLA-A*24:379 protein complex	HLA-A*24:379		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:379 chain	Beta-2-microglobulin		
 HLA-A*24:380 protein complex	HLA-A*24:380		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:380 chain	Beta-2-microglobulin		
 HLA-A*24:381 protein complex	HLA-A*24:381		complete molecule	equivalent	MHC class I protein complex	human	HLA-A*24:381 chain	Beta-2-microglobulin		
@@ -4579,6 +4589,7 @@ HLA-B*07:40 protein complex	HLA-B*07:40		complete molecule	equivalent	MHC class 
 HLA-B*07:41 protein complex	HLA-B*07:41		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*07:41 chain	Beta-2-microglobulin		
 HLA-B*07:42 protein complex	HLA-B*07:42		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*07:42 chain	Beta-2-microglobulin		
 HLA-B*07:43 protein complex	HLA-B*07:43		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*07:43 chain	Beta-2-microglobulin		
+HLA-B*07:44 protein complex	HLA-B*07:44		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*07:44 chain	Beta-2-microglobulin		
 HLA-B*07:45 protein complex	HLA-B*07:45		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*07:45 chain	Beta-2-microglobulin		
 HLA-B*07:46 protein complex	HLA-B*07:46		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*07:46 chain	Beta-2-microglobulin		
 HLA-B*07:47 protein complex	HLA-B*07:47		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*07:47 chain	Beta-2-microglobulin		
@@ -6008,6 +6019,7 @@ HLA-B*18:102 protein complex	HLA-B*18:102		complete molecule	equivalent	MHC clas
 HLA-B*18:103 protein complex	HLA-B*18:103		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*18:103 chain	Beta-2-microglobulin		
 HLA-B*18:104 protein complex	HLA-B*18:104		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*18:104 chain	Beta-2-microglobulin		
 HLA-B*18:105 protein complex	HLA-B*18:105		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*18:105 chain	Beta-2-microglobulin		
+HLA-B*18:106 protein complex	HLA-B*18:106		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*18:106 chain	Beta-2-microglobulin		
 HLA-B*18:107 protein complex	HLA-B*18:107		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*18:107 chain	Beta-2-microglobulin		
 HLA-B*18:108 protein complex	HLA-B*18:108		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*18:108 chain	Beta-2-microglobulin		
 HLA-B*18:109 protein complex	HLA-B*18:109		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*18:109 chain	Beta-2-microglobulin		
@@ -6271,6 +6283,7 @@ HLA-B*27:181 protein complex	HLA-B*27:181		complete molecule	equivalent	MHC clas
 HLA-B*27:182 protein complex	HLA-B*27:182		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*27:182 chain	Beta-2-microglobulin		
 HLA-B*27:183 protein complex	HLA-B*27:183		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*27:183 chain	Beta-2-microglobulin		
 HLA-B*27:184 protein complex	HLA-B*27:184		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*27:184 chain	Beta-2-microglobulin		
+HLA-B*27:185 protein complex	HLA-B*27:185		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*27:185 chain	Beta-2-microglobulin		
 HLA-B*27:186 protein complex	HLA-B*27:186		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*27:186 chain	Beta-2-microglobulin		
 HLA-B*27:187 protein complex	HLA-B*27:187		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*27:187 chain	Beta-2-microglobulin		
 HLA-B*27:188 protein complex	HLA-B*27:188		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*27:188 chain	Beta-2-microglobulin		
@@ -7607,6 +7620,7 @@ HLA-B*41:52 protein complex	HLA-B*41:52		complete molecule	equivalent	MHC class 
 HLA-B*41:53 protein complex	HLA-B*41:53		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*41:53 chain	Beta-2-microglobulin		
 HLA-B*41:54 protein complex	HLA-B*41:54		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*41:54 chain	Beta-2-microglobulin		
 HLA-B*41:55 protein complex	HLA-B*41:55		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*41:55 chain	Beta-2-microglobulin		
+HLA-B*41:56 protein complex	HLA-B*41:56		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*41:56 chain	Beta-2-microglobulin		
 HLA-B*41:57 protein complex	HLA-B*41:57		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*41:57 chain	Beta-2-microglobulin		
 HLA-B*41:58 protein complex	HLA-B*41:58		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*41:58 chain	Beta-2-microglobulin		
 HLA-B*41:59 protein complex	HLA-B*41:59		complete molecule	equivalent	MHC class I protein complex	human	HLA-B*41:59 chain	Beta-2-microglobulin		
@@ -9635,6 +9649,7 @@ HLA-C*03:17 protein complex	HLA-C*03:17		complete molecule	equivalent	MHC class 
 HLA-C*03:18 protein complex	HLA-C*03:18		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*03:18 chain	Beta-2-microglobulin		
 HLA-C*03:19 protein complex	HLA-C*03:19		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*03:19 chain	Beta-2-microglobulin		
 HLA-C*03:21 protein complex	HLA-C*03:21		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*03:21 chain	Beta-2-microglobulin		
+HLA-C*03:23 protein complex	HLA-C*03:23		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*03:23 chain	Beta-2-microglobulin		
 HLA-C*03:24 protein complex	HLA-C*03:24		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*03:24 chain	Beta-2-microglobulin		
 HLA-C*03:25 protein complex	HLA-C*03:25		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*03:25 chain	Beta-2-microglobulin		
 HLA-C*03:26 protein complex	HLA-C*03:26		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*03:26 chain	Beta-2-microglobulin		
@@ -10412,6 +10427,7 @@ HLA-C*04:334 protein complex	HLA-C*04:334		complete molecule	equivalent	MHC clas
 HLA-C*04:335 protein complex	HLA-C*04:335		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*04:335 chain	Beta-2-microglobulin		
 HLA-C*04:336 protein complex	HLA-C*04:336		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*04:336 chain	Beta-2-microglobulin		
 HLA-C*04:337 protein complex	HLA-C*04:337		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*04:337 chain	Beta-2-microglobulin		
+HLA-C*04:338 protein complex	HLA-C*04:338		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*04:338 chain	Beta-2-microglobulin		
 HLA-C*04:339 protein complex	HLA-C*04:339		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*04:339 chain	Beta-2-microglobulin		
 HLA-C*04:340 protein complex	HLA-C*04:340		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*04:340 chain	Beta-2-microglobulin		
 HLA-C*04:341 protein complex	HLA-C*04:341		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*04:341 chain	Beta-2-microglobulin		
@@ -11201,6 +11217,7 @@ HLA-C*07:222 protein complex	HLA-C*07:222		complete molecule	equivalent	MHC clas
 HLA-C*07:223 protein complex	HLA-C*07:223		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:223 chain	Beta-2-microglobulin		
 HLA-C*07:224 protein complex	HLA-C*07:224		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:224 chain	Beta-2-microglobulin		
 HLA-C*07:225 protein complex	HLA-C*07:225		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:225 chain	Beta-2-microglobulin		
+HLA-C*07:226 protein complex	HLA-C*07:226		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:226 chain	Beta-2-microglobulin		
 HLA-C*07:228 protein complex	HLA-C*07:228		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:228 chain	Beta-2-microglobulin		
 HLA-C*07:229 protein complex	HLA-C*07:229		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:229 chain	Beta-2-microglobulin		
 HLA-C*07:230 protein complex	HLA-C*07:230		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:230 chain	Beta-2-microglobulin		
@@ -11398,6 +11415,7 @@ HLA-C*07:428 protein complex	HLA-C*07:428		complete molecule	equivalent	MHC clas
 HLA-C*07:429 protein complex	HLA-C*07:429		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:429 chain	Beta-2-microglobulin		
 HLA-C*07:430 protein complex	HLA-C*07:430		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:430 chain	Beta-2-microglobulin		
 HLA-C*07:431 protein complex	HLA-C*07:431		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:431 chain	Beta-2-microglobulin		
+HLA-C*07:432 protein complex	HLA-C*07:432		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:432 chain	Beta-2-microglobulin		
 HLA-C*07:433 protein complex	HLA-C*07:433		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:433 chain	Beta-2-microglobulin		
 HLA-C*07:434 protein complex	HLA-C*07:434		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:434 chain	Beta-2-microglobulin		
 HLA-C*07:435 protein complex	HLA-C*07:435		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:435 chain	Beta-2-microglobulin		
@@ -11656,6 +11674,7 @@ HLA-C*07:709 protein complex	HLA-C*07:709		complete molecule	equivalent	MHC clas
 HLA-C*07:710 protein complex	HLA-C*07:710		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:710 chain	Beta-2-microglobulin		
 HLA-C*07:711 protein complex	HLA-C*07:711		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:711 chain	Beta-2-microglobulin		
 HLA-C*07:712 protein complex	HLA-C*07:712		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:712 chain	Beta-2-microglobulin		
+HLA-C*07:713 protein complex	HLA-C*07:713		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:713 chain	Beta-2-microglobulin		
 HLA-C*07:714 protein complex	HLA-C*07:714		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:714 chain	Beta-2-microglobulin		
 HLA-C*07:715 protein complex	HLA-C*07:715		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:715 chain	Beta-2-microglobulin		
 HLA-C*07:716 protein complex	HLA-C*07:716		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*07:716 chain	Beta-2-microglobulin		
@@ -12119,6 +12138,7 @@ HLA-C*12:135 protein complex	HLA-C*12:135		complete molecule	equivalent	MHC clas
 HLA-C*12:136 protein complex	HLA-C*12:136		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*12:136 chain	Beta-2-microglobulin		
 HLA-C*12:137 protein complex	HLA-C*12:137		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*12:137 chain	Beta-2-microglobulin		
 HLA-C*12:138 protein complex	HLA-C*12:138		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*12:138 chain	Beta-2-microglobulin		
+HLA-C*12:139 protein complex	HLA-C*12:139		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*12:139 chain	Beta-2-microglobulin		
 HLA-C*12:140 protein complex	HLA-C*12:140		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*12:140 chain	Beta-2-microglobulin		
 HLA-C*12:141 protein complex	HLA-C*12:141		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*12:141 chain	Beta-2-microglobulin		
 HLA-C*12:142 protein complex	HLA-C*12:142		complete molecule	equivalent	MHC class I protein complex	human	HLA-C*12:142 chain	Beta-2-microglobulin		
@@ -18106,9 +18126,13 @@ crab-eating macaque MHC class II protein complex	crab-eating macaque		class	equi
 dog MHC class I protein complex	dog		class	equivalent	MHC class I protein complex	dog				
 dog MHC class II protein complex	dog		class	equivalent	MHC class II protein complex	dog				
 duck MHC class I protein complex	duck		class	equivalent	MHC class I protein complex	duck				
+giant panda MHC class I protein complex	giant panda		class	equivalent	MHC class I protein complex	giant panda				
+giant panda MHC class II protein complex	giant panda		class	equivalent	MHC class II protein complex	giant panda				
 gorilla MHC class I protein complex	gorilla		class	equivalent	MHC class I protein complex	gorilla				
 gorilla MHC class I protein complex	gorilla		class	equivalent	MHC class I protein complex	gorilla				
 gorilla MHC class II protein complex	gorilla		class	equivalent	MHC class II protein complex	gorilla				
+grass carp MHC class I protein complex	grass carp		class	equivalent	MHC class I protein complex	grass carp				
+grass carp MHC class II protein complex	grass carp		class	equivalent	MHC class II protein complex	grass carp				
 horse MHC class I protein complex	horse		class	equivalent	MHC class I protein complex	horse				
 horse MHC class II protein complex	horse		class	equivalent	MHC class II protein complex	horse				
 human BTN3A1 protein complex	human BTN3A1	Butyrophilin BTN3A1	complete molecule	equivalent	non-classical MHC protein complex	human	human BTN3A1 chain			

--- a/src/clean.py
+++ b/src/clean.py
@@ -40,7 +40,9 @@ organisms = {
   'crab-eating macaque': 'crab-eating macaque (Macaca fascicularis)',
   'dog': 'dog (Canis lupus familiaris)',
   'duck': 'duck (Anas platyrhynchos)',
+  'giant panda': 'giant panda (Ailuropoda melanoleuca)',
   'gorilla': 'gorilla (Gorilla gorilla)',
+  'grass carp': 'grass carp (Ctenopharyngodon idella)',
   'horse': 'horse (Equus caballus)',
   'human': 'human (Homo sapiens)',
   'marmoset': 'marmoset (Callithrix jacchus)',
@@ -54,6 +56,7 @@ organisms = {
 }
 codes = {
   '1': 'organism',
+  '7959': 'Ctid',
   '8355': 'clawed frog',
   '8839': 'duck',
   '9031': 'chicken',
@@ -66,6 +69,7 @@ codes = {
   '9598': 'Patr',
   '9606': 'HLA',
   '9615': 'DLA',
+  '9646': 'Aime',
   '9685': 'FLA',
   '9796': 'ELA',
   '9823': 'SLA',

--- a/src/clean.py
+++ b/src/clean.py
@@ -26,76 +26,28 @@ parser = argparse.ArgumentParser(
 parser.add_argument('alleles',
     type=argparse.FileType('r'),
     help='read query result CSV')
+parser.add_argument('external',
+    type=argparse.FileType('r'),
+    help='read external template')
 args = parser.parse_args()
 
-organisms = {
-  'black flying fox': 'black flying fox (Pteropus alecto)',
-  'bonobo': 'bonobo (Pan paniscus)',
-  'cat': 'cat (Felis catus)',
-  'cattle': 'cattle (Bos taurus)',
-  'chicken': 'chicken (Gallus gallus)',
-  'chimpanzee': 'chimpanzee (Pan troglodytes)',
-  'clawed frog': 'clawed frog (Xenopus laevis)',
-  'cotton-top tamarin': 'cotton-top tamarin (Saguinus oedipus)',
-  'crab-eating macaque': 'crab-eating macaque (Macaca fascicularis)',
-  'dog': 'dog (Canis lupus familiaris)',
-  'duck': 'duck (Anas platyrhynchos)',
-  'giant panda': 'giant panda (Ailuropoda melanoleuca)',
-  'gorilla': 'gorilla (Gorilla gorilla)',
-  'grass carp': 'grass carp (Ctenopharyngodon idella)',
-  'horse': 'horse (Equus caballus)',
-  'human': 'human (Homo sapiens)',
-  'marmoset': 'marmoset (Callithrix jacchus)',
-  'mouse': 'mouse (Mus musculus)',
-  'organism': 'organism (all species)',
-  'pig': 'pig (Sus scrofa)',
-  'rabbit': 'rabbit (Oryctolagus cuniculus)',
-  'rat': 'rat (Rattus norvegicus)',
-  'rhesus macaque': 'rhesus macaque (Macaca mulatta)',
-  'sheep': 'sheep (Ovis aries)'
-}
-codes = {
-  '1': 'organism',
-  '7959': 'Ctid',
-  '8355': 'clawed frog',
-  '8839': 'duck',
-  '9031': 'chicken',
-  '9483': 'marmoset',
-  '9490': 'Saoe',
-  '9544': 'Mamu',
-  '9541': 'Mafa',
-  '9593': 'Gogo',
-  '9597': 'Papa',
-  '9598': 'Patr',
-  '9606': 'HLA',
-  '9615': 'DLA',
-  '9646': 'Aime',
-  '9685': 'FLA',
-  '9796': 'ELA',
-  '9823': 'SLA',
-  '9913': 'BoLA',
-  '9940': 'Ovar',
-  '9986': 'RLA',
-  '10090': 'H2',
-  '10116': 'rat'
-}
+# Create organism -> long name & organism ID -> code
+
+organisms = {}
+codes = {}
+ext = csv.DictReader(args.external, delimiter="\t")
+for row in ext:
+  if row["Parent"] != "organism":
+    continue
+  ncbi_id = row["ID"].split(":")[1]
+  organism_label = row["Label"]
+  scientific_label = row["Editor Preferred Term"]
+  organisms[organism_label] = f"{organism_label} ({scientific_label})"
+  codes[ncbi_id] = row["Species Code"]
 
 def clean_code(name):
-  return name.replace('BF-','') \
-             .replace('BoLA-','') \
-             .replace('Caja-','') \
-             .replace('DLA-','') \
-             .replace('ELA-','') \
-             .replace('Gogo-','') \
-             .replace('H2-','') \
-             .replace('HLA-','') \
-             .replace('Mamu-','') \
-             .replace('Papa-','') \
-             .replace('Patr-','') \
-             .replace('Saoe-','') \
-             .replace('SLA-','') \
-             .replace('RT1-','') \
-             .replace('RLA-', '')
+  for code in codes.values():
+    name = name.replace(f"{code}-", "")
 
 # Grab the first row and use those headers.
 

--- a/src/update_seqs.py
+++ b/src/update_seqs.py
@@ -24,8 +24,6 @@ def main():
       default=False)
   args = parser.parse_args()
 
-  print(args.overwrite)
-
   # Read one or more FASTA files into a dictionary
   seqs = {}
   for fasta in args.fasta:

--- a/src/update_seqs.py
+++ b/src/update_seqs.py
@@ -18,7 +18,13 @@ def main():
       type=argparse.FileType('r'),
       nargs='+',
       help='FASTA file(s) to read')
+  parser.add_argument('-o',
+      '--overwrite',
+      action='store_true',
+      default=False)
   args = parser.parse_args()
+
+  print(args.overwrite)
 
   # Read one or more FASTA files into a dictionary
   seqs = {}
@@ -56,7 +62,8 @@ def main():
   # Update sequences from FASTAs by matching accession
   for row in rows:
     if len(row) > 2 and row[3] in seqs:
-      row[4] = seqs[row[3]]
+      if not row[4] or (row[4] and args.overwrite):
+        row[4] = seqs[row[3]]
 
   # Overwrite chain-sequence.tsv
   with open(args.filename, 'w') as f:


### PR DESCRIPTION
## New Terms

This PR adds two new species:
* giant panda (NCBITaxon:9646)
* grass carp (NCBITaxon:7959)

It adds 18 terms related to these new species:

ID | Label
-- | --
MRO:0036986 | giant panda MHC class I locus
MRO:0036987 | giant panda MHC class II locus
MRO:0036988 | grass carp MHC class I locus
MRO:0036989 | grass carp MHC class II locus
MRO:0036990 | Aime-128 locus
MRO:0036991 | Ctid-UAA locus
MRO:0036992 | Aime-128 chain
MRO:0036993 | Ctid-UAA chain
MRO:0037012 | Aime-128 protein complex
MRO:0037013 | Ctid-UAA protein complex
MRO:0037032 | giant panda MHC class I chain
MRO:0037033 | giant panda MHC class II chain
MRO:0037034 | grass carp MHC class I chain
MRO:0037035 | grass carp MHC class II chain
MRO:0037036 | giant panda MHC class I protein complex
MRO:0037037 | giant panda MHC class II protein complex
MRO:0037038 | grass carp MHC class I protein complex
MRO:0037039 | grass carp MHC class II protein complex

As well as 36 new HLA terms (18 chain terms and 18 protein complex terms)

## Code Changes

I updated `src/clean.py` to include these two new species with the codes Ctid (grass carp) and Amie (giant panda). Question for @jamesaoverton and/or @rvita - should the code for "chicken" actually be "Gaga" to match with the other terms? Same with duck (Anpl), clawed frog (Xela), etc. See here:
https://github.com/IEDB/MRO/blob/5be1c689c04fc523036f5480cd38eaa3a16bdf3c/src/clean.py#L57-L80

I also updated `src/update_seqs.py` to have an `-o`/`--overwrite` flag. There are now two tasks for sequences (I was getting sick of doing this manually because some of the HLA terms have updates that we don't want to include):
* `update-seqs`: adds sequences where missing
* `refresh-seqs`: adds sequences where missing & overwrites old ones with changes (if any change)