### PR TITLE
2020-12-02 update

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -18334,3 +18334,7 @@ BoLA-DRB3*020:04 protein complex	18426	DRB3
 BoLA-DQA*012:04 protein complex	18427	DQ		
 Aime-128 protein complex	18428	128		
 Ctid-UAA protein complex	18429	UAA		
+Mafa-A1*063:01 protein complex	18430	A1		
+Mafa-A1 protein complex	18431	A1		
+crab-eating macaque MHC class I protein complex	18432			
+crab-eating macaque MHC class II protein complex	18433			

--- a/index.tsv
+++ b/index.tsv
@@ -37040,3 +37040,11 @@ MRO:0037036	giant panda MHC class I protein complex	owl:Class
 MRO:0037037	giant panda MHC class II protein complex	owl:Class	
 MRO:0037038	grass carp MHC class I protein complex	owl:Class	
 MRO:0037039	grass carp MHC class II protein complex	owl:Class	
+MRO:0037040	Mafa-A1 locus	owl:Class	
+MRO:0037041	crab-eating macaque MHC class I locus	owl:Class	
+MRO:0037042	Mafa-A1 chain	owl:Class	
+MRO:0037043	Mafa-A1*063:01 chain	owl:Class	
+MRO:0037044	crab-eating macaque MHC class I chain	owl:Class	
+MRO:0037045	Mafa-A1*063:01 protein complex	owl:Class	
+MRO:0037046	Mafa-A1 protein complex	owl:Class	
+MRO:0037047	crab-eating macaque MHC class I protein complex	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -17865,6 +17865,8 @@ HLA-G*01:24 chain		subclass	HLA-G chain
 HLA-MR1 chain		equivalent	protein	HLA-MR1 locus	
 MHC class I chain		equivalent	protein	MHC class I locus	
 MHC class II chain		equivalent	protein	MHC class II locus	
+Mafa-A1 chain		equivalent	protein	Mafa-A1 locus	
+Mafa-A1*063:01 chain		subclass	Mafa-A1 chain		
 Mafa-DQA chain		equivalent	protein	Mafa-DQA locus	
 Mafa-DQB1*18:01 chain		subclass	Mafa-DQB chain		
 Mafa-DQB chain		equivalent	protein	Mafa-DQB locus	
@@ -18051,6 +18053,7 @@ chimpanzee non-classical MHC chain		equivalent	protein	chimpanzee non-classical 
 clawed frog MHC class I chain		equivalent	protein	clawed frog MHC class I locus	
 cotton-top tamarin MHC class I chain		equivalent	protein	cotton-top tamarin MHC class I locus	
 cotton-top tamarin MHC class II chain		equivalent	protein	cotton-top tamarin MHC class II locus	
+crab-eating macaque MHC class I chain		equivalent	protein	crab-eating macaque MHC class I locus	
 crab-eating macaque MHC class II chain		equivalent	protein	crab-eating macaque MHC class II locus	
 dog MHC class I chain		equivalent	protein	dog MHC class I locus	
 dog MHC class II chain		equivalent	protein	dog MHC class II locus	

--- a/ontology/genetic-locus.tsv
+++ b/ontology/genetic-locus.tsv
@@ -62,6 +62,7 @@ HLA-G locus		subclass	human non-classical MHC locus
 HLA-MR1 locus		subclass	human non-classical MHC locus	
 MHC class I locus		subclass	MHC locus	
 MHC class II locus		subclass	MHC locus	
+Mafa-A1 locus		subclass	crab-eating macaque MHC class I locus	
 Mafa-DQA locus		subclass	crab-eating macaque MHC class II locus	
 Mafa-DQB locus		subclass	crab-eating macaque MHC class II locus	
 Mafa-DRA locus		subclass	crab-eating macaque MHC class II locus	
@@ -120,6 +121,7 @@ clawed frog MHC class I locus		subclass	MHC class I locus	clawed frog
 clawed frog MHC class II locus		subclass	MHC class II locus	clawed frog
 cotton-top tamarin MHC class I locus		subclass	MHC class I locus	cotton-top tamarin
 cotton-top tamarin MHC class II locus		subclass	MHC class II locus	cotton-top tamarin
+crab-eating macaque MHC class I locus		subclass	MHC class I locus	crab-eating macaque
 crab-eating macaque MHC class II locus		subclass	MHC class II locus	crab-eating macaque
 dog MHC class I locus		subclass	MHC class I locus	dog
 dog MHC class II locus		subclass	MHC class II locus	dog

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -17953,6 +17953,8 @@ HLA-G*01:23 protein complex	HLA-G*01:23		complete molecule	equivalent	non-classi
 HLA-G*01:24 protein complex	HLA-G*01:24		complete molecule	equivalent	non-classical MHC protein complex	human	HLA-G*01:24 chain	Beta-2-microglobulin		
 MHC class I protein complex	class I		class	subclass	MHC protein complex					
 MHC class II protein complex	class II		class	subclass	MHC protein complex					
+Mafa-A1 protein complex	Mafa-A1		locus	equivalent	MHC class I protein complex	crab-eating macaque	Mafa-A1 chain	Beta-2-microglobulin		
+Mafa-A1*063:01 protein complex	Mafa-A1*063:01		complete molecule	equivalent	MHC class I protein complex	crab-eating macaque	Mafa-A1*063:01 chain	Beta-2-microglobulin		
 Mafa-DQB1*18:01 protein complex	Mafa-DQB1*1801		partial molecule	equivalent	MHC class II protein complex	crab-eating macaque	Mafa-DQA chain	Mafa-DQB1*18:01 chain		
 Mafa-DQB protein complex	Mafa-DQB		locus	equivalent	MHC class II protein complex	crab-eating macaque	Mafa-DQA chain	Mafa-DQB chain		
 Mafa-DRB protein complex	Mafa-DRB		locus	equivalent	MHC class II protein complex	crab-eating macaque	Mafa-DRA chain	Mafa-DRB chain		
@@ -18122,6 +18124,7 @@ clawed frog MHC class II protein complex	clawed frog		class	equivalent	MHC class
 cotton-top tamarin MHC class I protein complex	cotton-top tamarin		class	equivalent	MHC class I protein complex	cotton-top tamarin				
 cotton-top tamarin MHC class I protein complex	cotton-top tamarin		class	equivalent	MHC class I protein complex	cotton-top tamarin				
 cotton-top tamarin MHC class II protein complex	cotton-top tamarin		class	equivalent	MHC class II protein complex	cotton-top tamarin				
+crab-eating macaque MHC class I protein complex	crab-eating macaque		class	equivalent	MHC class I protein complex	crab-eating macaque				
 crab-eating macaque MHC class II protein complex	crab-eating macaque		class	equivalent	MHC class II protein complex	crab-eating macaque				
 dog MHC class I protein complex	dog		class	equivalent	MHC class I protein complex	dog				
 dog MHC class II protein complex	dog		class	equivalent	MHC class II protein complex	dog				


### PR DESCRIPTION
This PR includes 8 new terms:

ID | Label
--- | ---
MRO:0037040 | Mafa-A1 locus
MRO:0037041 | crab-eating macaque MHC class I locus
MRO:0037042 | Mafa-A1 chain
MRO:0037043 | Mafa-A1*063:01 chain
MRO:0037044 | crab-eating macaque MHC class I chain
MRO:0037045 | Mafa-A1*063:01 protein complex
MRO:0037046 | Mafa-A1 protein complex
MRO:0037047 | crab-eating macaque MHC class I protein complex