### PR TITLE
First pass at fixing imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,9 +228,8 @@ update-cow-alleles: src/update_cow_alleles.py ontology/chain-sequence.tsv ontolo
 ### OWL Files
 
 mro.owl: build/mro-import.owl index.tsv $(build_files) ontology/metadata.ttl | build/robot.jar
-	$(ROBOT) merge \
+	$(ROBOT) template \
 	--input $< \
-	template \
 	--prefix "MRO: $(OBO)/MRO_" \
 	--prefix "REO: $(OBO)/REO_" \
 	--template index.tsv \

--- a/Makefile
+++ b/Makefile
@@ -291,9 +291,6 @@ PREDICATES := IAO:0000111 IAO:0000112 IAO:0000115 IAO:0000119 IAO:0000412 OBI:99
 build/%-import.ttl: build/%.db build/%.txt
 	python3 -m gizmos.extract -d $< -T $(word 2,$^) $(foreach P,$(PREDICATES), -p $(P)) > $@
 
-build/%-import.owl: build/%-import-structure.owl build/%-import-annotations.ttl | build/robot.jar
-	$(ROBOT) merge --input $< --input $(word 2,$^) --output $@
-
 ### Generate files for IEDB
 #
 # This includes an extended OWL file

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build build/validate:
 # We use the official development version of ROBOT for most things.
 
 build/robot.jar: | build
-	curl -L -o $@ https://build.obolibrary.io/job/ontodev/job/robot/job/accept-tdb/lastSuccessfulBuild/artifact/bin/robot.jar
+	curl -L -o $@ https://build.obolibrary.io/job/ontodev/job/robot/job/master/lastSuccessfulBuild/artifact/bin/robot.jar
 
 # Download rdftab based on operating system
 

--- a/Makefile
+++ b/Makefile
@@ -246,29 +246,53 @@ mro.owl: build/mro-import.owl index.tsv $(build_files) ontology/metadata.ttl | b
 	--annotation-file ontology/metadata.ttl \
 	--output $@
 
-build/mro-import.owl: ontology/import.txt $(LIB)/ro.owl $(LIB)/obi.owl $(LIB)/eco.owl | build/robot.jar
+build/mro-import.owl: build/eco-import.ttl build/iao-import.ttl build/obi-import.ttl build/ro-import.ttl ontology/import.txt | build/robot.jar
 	$(ROBOT) merge \
-	--input $(LIB)/eco.owl \
-	--input $(LIB)/obi.owl \
-	--input $(LIB)/ro.owl \
+	--input build/eco-import.ttl \
+	--input build/obi-import.ttl \
+	--input build/ro-import.ttl \
+	--input build/iao-import.ttl \
 	extract \
 	--method MIREOT \
-	--prefix "REO: $(OBO)/REO_" \
 	--upper-term "GO:0008150" \
 	--upper-term "IAO:0000030" \
 	--upper-term "OBI:1110128" \
 	--upper-term "ECO:0000000" \
 	--upper-term "BFO:0000040" \
 	--upper-term "PR:000000001" \
-	--lower-terms $< \
+	--lower-terms $(word 5,$^) \
 	--output $@
-
 
 # fetch ontology dependencies
 $(LIB)/%:
 	mkdir -p $(LIB)
 	cd $(LIB) && curl -LO "$(OBO)/$*"
 
+UC = $(shell echo '$1' | tr '[:lower:]' '[:upper:]')
+
+# OBI IAO:0000115 has mulitples so get the definiton from here
+# we could also just add this to index.tsv
+build/%.txt: ontology/import.txt | build
+	sed -n '/$(call UC,$(notdir $(basename $@)))/p' $< > $@
+
+# RO:0000056 isn't in RO?
+# we could also just add this to index.tsv
+build/obi.txt: ontology/import.txt | build
+	sed '/^ECO/d' $< | sed '/^RO/d' | sed '/^IAO/d' > $@
+	echo "RO:0000056" >> $@
+
+build/%.db: src/scripts/prefixes.sql $(LIB)/%.owl | build/rdftab
+	rm -rf $@
+	sqlite3 $@ < $<
+	./build/rdftab $@ < $(word 2,$^)
+
+PREDICATES := IAO:0000111 IAO:0000112 IAO:0000115 IAO:0000119 IAO:0000412 OBI:9991118 rdfs:label
+
+build/%-import.ttl: build/%.db build/%.txt
+	python3 -m gizmos.extract -d $< -T $(word 2,$^) $(foreach P,$(PREDICATES), -p $(P)) > $@
+
+build/%-import.owl: build/%-import-structure.owl build/%-import-annotations.ttl | build/robot.jar
+	$(ROBOT) merge --input $< --input $(word 2,$^) --output $@
 
 ### Generate files for IEDB
 #

--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -1,8 +1,7 @@
 ID	Label	Editor Preferred Term	IEDB Label	Class Type	Parent	Logic	Definition	Definition Source	Example of Usage	Source Ontology	Species Code
 ID	A rdfs:label	A IAO:0000111	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A IAO:0000119	A IAO:0000112	AI IAO:0000412	
 ECO:0000000	evidence	evidence		subclass	information content entity					http://purl.obolibrary.org/obo/eco.owl	
-GO:0042611	MHC protein complex	MHC protein complex	MHC molecule	equivalent	protein complex	('has part' some (protein and ('gene product of' some 'MHC locus')))	A transmembrane protein complex composed of an MHC alpha chain and, in most cases, either an MHC class II beta chain or an invariant beta2-microglobin chain, and with or without a bound peptide, lipid, or polysaccharide antigen.	GO		http://purl.obolibrary.org/obo/go.owl	
-GO:0043234	protein complex	protein complex	MHC	subclass	material entity					http://purl.obolibrary.org/obo/go.owl	
+GO:0042611	MHC protein complex	MHC protein complex	MHC molecule	equivalent	protein-containing complex	('has part' some (protein and ('gene product of' some 'MHC locus')))	A transmembrane protein complex composed of an MHC alpha chain and, in most cases, either an MHC class II beta chain or an invariant beta2-microglobin chain, and with or without a bound peptide, lipid, or polysaccharide antigen.	GO		http://purl.obolibrary.org/obo/go.owl		
 NCBITaxon:7959	grass carp	Ctenopharyngodon idella		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ctid
 NCBITaxon:8355	clawed frog	Xenopus laevis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Xela
 NCBITaxon:8839	duck	Anas platyrhynchos		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Anpl

--- a/ontology/import.txt
+++ b/ontology/import.txt
@@ -1,9 +1,6 @@
 # Biology
 GO:0008150  # biological process
 OBI:1110057 # MHC:epitope complex binding to TCR
-REO:0000079 # genetic locus
-SO:0001024  # haplotype
-SO:0000355  # haplotype_block
 
 # Information
 IAO:0000030 # information content entity
@@ -19,7 +16,7 @@ OBI:1110037 # T cell epitope recognition assay
 
 # Material
 BFO:0000040 # material entity
-GO:0043234  # protein complex
+GO:0032991 # protein-containing complex
 PR:000000001 # protein
 OBI:1110001 # epitope
 OBI:0100026 # organism
@@ -40,7 +37,9 @@ RO:0002162  # in taxon
 RO:0002204  # gene product of
 
 # Annotation Properties
+IAO:0000111 # editor preferred term
 IAO:0000115 # definition
 IAO:0000119 # definition source
 IAO:0000112 # example of usage
+IAO:0000412 # imported from
 OBI:9991118 # IEDB alternative term

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cerberus
 ontodev-cogs
-ontodev-gizmos==0.1.3
+ontodev-gizmos
 openpyxl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cerberus
 ontodev-cogs
-ontodev-gizmos
+ontodev-gizmos==0.1.5
 openpyxl

--- a/src/scripts/prefixes.sql
+++ b/src/scripts/prefixes.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS prefix (
+  prefix TEXT PRIMARY KEY,
+  base TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO prefix VALUES
+("BFO",       "http://purl.obolibrary.org/obo/BFO_"),
+("ECO",       "http://purl.obolibrary.org/obo/ECO_"),
+("GO",        "http://purl.obolibrary.org/obo/GO_"),
+("IAO",       "http://purl.obolibrary.org/obo/IAO_"),
+("OBI",       "http://purl.obolibrary.org/obo/OBI_"),
+("oio",       "http://www.geneontology.org/formats/oboInOwl#"),
+("owl",       "http://www.w3.org/2002/07/owl#"),
+("PR",        "http://purl.obolibrary.org/obo/PR_"),
+("REO",       "http://purl.obolibrary.org/obo/REO_"),
+("rdf",       "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+("rdfs",      "http://www.w3.org/2000/01/rdf-schema#"),
+("RO",        "http://purl.obolibrary.org/obo/RO_");


### PR DESCRIPTION
This uses an unreleased version of `ontodev-gizmos`. It's the most recent on the master branch: https://github.com/ontodev/gizmos

Instead of importing all terms from all imports, this divides the imports into different subsets and extracts only what we need from each import. It also adds an IAO import to resolve the OBI issue where many IAO terms have multiple labels, definitions, etc. The OBI import text file is a little different because it includes GO & PR terms.

I then added a second extract step with ROBOT after everything is merged to make sure we don't get the *full* hierarchy of terms, since `gizmos.extract` goes all the way to the top.

Note that I updated "protein complex" to "protein-containing complex" here, because it fails otherwise (this old term no longer exists in OBI). See #70. Also, "genetic locus", "haplotype", and "haplotype_block" were never in any of the imports; they just exist in our external file.

Travis fails with:
```
MANCHESTER PARSE ERROR the expression ''information content entity'' at row 3, column 6 in table "build/external.tsv" cannot be parsed: encountered unknown 'information content entity'
```
... but this passes OK locally. @jamesaoverton whenever you have a chance, could you test this on your system to see if you get this error? I feel like we've had this issue before.