### PR TITLE
2020-12-15 update

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -18333,8 +18333,9 @@ BoLA-2*016:01 protein complex	18425	2
 BoLA-DRB3*020:04 protein complex	18426	DRB3		
 BoLA-DQA*012:04 protein complex	18427	DQ		
 Aime-128 protein complex	18428	128		
-Ctid-UAA protein complex	18429	UAA		
+Ctid-UAA b2m-1-II protein complex	18429	UAA		
 Mafa-A1*063:01 protein complex	18430	A1		
 Mafa-A1 protein complex	18431	A1		
 crab-eating macaque MHC class I protein complex	18432			
 crab-eating macaque MHC class II protein complex	18433			
+Ctid-UAA b2m-2 protein complex	18434			

--- a/index.tsv
+++ b/index.tsv
@@ -37053,5 +37053,5 @@ MRO:0037049	Beta-2-microglobulin locus	owl:Class
 MRO:0037050	grass carp Beta-2-microglobulin-1-II chain	owl:Class	
 MRO:0037051	grass carp Beta-2-microglobulin-2 chain	owl:Class	
 MRO:0037052	grass carp Beta-2-microglobulin chain	owl:Class	
-MRO:0037053	Beta-2-microglobulin chain	owl:Class	
-MRO:0037054	Ctid-UAA b2m-2 protein complex	owl:Class	
+MRO:0037053	Ctid-UAA b2m-2 protein complex	owl:Class	
+			

--- a/index.tsv
+++ b/index.tsv
@@ -37013,7 +37013,7 @@ MRO:0037009	HLA-C*12:139 chain	owl:Class
 MRO:0037010	HLA-B*07:44 chain	owl:Class	
 MRO:0037011	HLA-C*03:23 chain	owl:Class	
 MRO:0037012	Aime-128 protein complex	owl:Class	
-MRO:0037013	Ctid-UAA protein complex	owl:Class	
+MRO:0037013	Ctid-UAA b2m-1-II protein complex	owl:Class	
 MRO:0037014	HLA-A*01:159 protein complex	owl:Class	
 MRO:0037015	HLA-A*01:281 protein complex	owl:Class	
 MRO:0037016	HLA-A*02:437 protein complex	owl:Class	
@@ -37048,3 +37048,10 @@ MRO:0037044	crab-eating macaque MHC class I chain	owl:Class
 MRO:0037045	Mafa-A1*063:01 protein complex	owl:Class	
 MRO:0037046	Mafa-A1 protein complex	owl:Class	
 MRO:0037047	crab-eating macaque MHC class I protein complex	owl:Class	
+MRO:0037048	grass carp Beta-2-microglobulin locus	owl:Class	
+MRO:0037049	Beta-2-microglobulin locus	owl:Class	
+MRO:0037050	grass carp Beta-2-microglobulin-1-II chain	owl:Class	
+MRO:0037051	grass carp Beta-2-microglobulin-2 chain	owl:Class	
+MRO:0037052	grass carp Beta-2-microglobulin chain	owl:Class	
+MRO:0037053	Beta-2-microglobulin chain	owl:Class	
+MRO:0037054	Ctid-UAA b2m-2 protein complex	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -1,6 +1,5 @@
 Label	Synonyms	Class Type	Parent	Gene	Expression
 LABEL	A IAO:0000118 SPLIT=|	CLASS_TYPE	C %	C 'gene product of' some %	AI 'has expression evidence'
-					
 Aime-128 chain		equivalent	protein	Aime-128 locus	
 Anpl-UAA chain		equivalent	protein	Anpl-UAA locus	
 Anpl-UAA*01 chain		subclass	Anpl-UAA chain		

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -1,9 +1,9 @@
 Label	Synonyms	Class Type	Parent	Gene	Expression
 LABEL	A IAO:0000118 SPLIT=|	CLASS_TYPE	C %	C 'gene product of' some %	AI 'has expression evidence'
+					
 Aime-128 chain		equivalent	protein	Aime-128 locus	
 Anpl-UAA chain		equivalent	protein	Anpl-UAA locus	
 Anpl-UAA*01 chain		subclass	Anpl-UAA chain		
-Beta-2-microglobulin chain		equivalent	protein	Beta-2-microglobulin locus	
 BoLA-1 chain		equivalent	protein	BoLA-1 locus	
 BoLA-1*007:01 chain		subclass	BoLA-1 chain		
 BoLA-1*009:01 chain		subclass	BoLA-1 chain		

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -3,6 +3,7 @@ LABEL	A IAO:0000118 SPLIT=|	CLASS_TYPE	C %	C 'gene product of' some %	AI 'has ex
 Aime-128 chain		equivalent	protein	Aime-128 locus	
 Anpl-UAA chain		equivalent	protein	Anpl-UAA locus	
 Anpl-UAA*01 chain		subclass	Anpl-UAA chain		
+Beta-2-microglobulin chain		equivalent	protein	Beta-2-microglobulin locus	
 BoLA-1 chain		equivalent	protein	BoLA-1 locus	
 BoLA-1*007:01 chain		subclass	BoLA-1 chain		
 BoLA-1*009:01 chain		subclass	BoLA-1 chain		
@@ -18062,6 +18063,9 @@ giant panda MHC class I chain		equivalent	protein	giant panda MHC class I locus
 giant panda MHC class II chain		equivalent	protein	giant panda MHC class II locus	
 gorilla MHC class I chain		equivalent	protein	gorilla MHC class I locus	
 gorilla MHC class II chain		equivalent	protein	gorilla MHC class II locus	
+grass carp Beta-2-microglobulin chain		equivalent	protein	grass carp Beta-2-microglobulin locus	
+grass carp Beta-2-microglobulin-1-II chain		subclass	grass carp Beta-2-microglobulin chain		
+grass carp Beta-2-microglobulin-2 chain		subclass	grass carp Beta-2-microglobulin chain		
 grass carp MHC class I chain		equivalent	protein	grass carp MHC class I locus	
 grass carp MHC class II chain		equivalent	protein	grass carp MHC class II locus	
 horse MHC class I chain		equivalent	protein	horse MHC class I locus	

--- a/ontology/core.tsv
+++ b/ontology/core.tsv
@@ -1,5 +1,6 @@
 Label	IEDB Label	Class Type	Parent	Logic	Definition	Definition Source	Example of Usage
 LABEL	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A IAO:0000119	A IAO:0000112
+Beta-2-microglobulin locus		subclass	genetic locus		The region of a chromosome that codes for Beta-2-microglobulin molecules.	IEDB	
 MHC haplotype		subclass	SO:0001024		A set of MHC alleles that is frequently inherited together.	IEDB	The mouse H-2-k class II haplotype is expressed in C3H mice.
 MHC ligand assay		subclass	immune epitope assay				
 MHC locus		subclass	genetic locus		The region of a chromosome that codes for MHC molecules.	IEDB	The class II regions encoding for the DP, DQ, and DR molecules on human chromosome 6.

--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -27,7 +27,7 @@ NCBITaxon:9986	rabbit	Oryctolagus cuniculus		subclass	organism					http://purl.o
 NCBITaxon:10090	mouse	Mus musculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	H2
 NCBITaxon:10116	rat	Rattus norvegicus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	RT1
 PR:000000001	protein	protein		subclass	material entity					http://purl.obolibrary.org/obo/pr.owl	
-PR:000004580	Beta-2-microglobulin	Beta-2-microglobulin		subclass	protein		A protein that is a translation product of the human B2M gene or a 1:1 ortholog thereof.			http://purl.obolibrary.org/obo/pr.owl	
+PR:000004580	Beta-2-microglobulin	Beta-2-microglobulin		equivalent	protein	('gene product of' some 'Beta-2-microglobulin locus')	A protein that is a translation product of the human B2M gene or a 1:1 ortholog thereof.			http://purl.obolibrary.org/obo/pr.owl	
 REO:0000079	genetic locus	genetic locus		subclass	genetic entity		a nucleic acid sequence region that is part of a genome and represents a specified location or region on a chromosome or other genomic element.			http://purl.obolibrary.org/obo/reo.owl	
 SO:0000355	haplotype_block	haplotype_block		subclass	genetic entity		A region of the genome which is co-inherited as the result of the lack of historic recombination within it.			http://purl.obolibrary.org/obo/so.owl	
 SO:0001024	haplotype	haplotype		subclass	genetic entity		A haplotype is one of a set of coexisting sequence variants of a haplotype block.			http://purl.obolibrary.org/obo/so.owl	

--- a/ontology/genetic-locus.tsv
+++ b/ontology/genetic-locus.tsv
@@ -130,6 +130,7 @@ giant panda MHC class I locus		subclass	MHC class I locus	giant panda
 giant panda MHC class II locus		subclass	MHC class II locus	giant panda
 gorilla MHC class I locus		subclass	MHC class I locus	gorilla
 gorilla MHC class II locus		subclass	MHC class II locus	gorilla
+grass carp Beta-2-microglobulin locus		subclass	Beta-2-microglobulin locus	grass carp
 grass carp MHC class I locus		subclass	MHC class I locus	grass carp
 grass carp MHC class II locus		subclass	MHC class II locus	grass carp
 horse MHC class I locus		subclass	MHC class I locus	horse

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -655,7 +655,8 @@ BoLA-DRB3*163:01 protein complex	BoLA-DRB3*163:01		partial molecule	equivalent	M
 BoLA-DRB6 protein complex	BoLA-DRB6		locus	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB6 chain		
 Caja-E protein complex	Caja-E		locus	equivalent	MHC class I protein complex	marmoset	Caja-E chain	Beta-2-microglobulin		
 Caja-G protein complex	Caja-G		locus	equivalent	MHC class I protein complex	marmoset	Caja-G chain	Beta-2-microglobulin		
-Ctid-UAA protein complex	Ctid-UAA		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	Beta-2-microglobulin		
+Ctid-UAA b2m-1-II protein complex	Ctid-UAA		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-1-II chain		
+Ctid-UAA b2m-2 protein complex	Ctid-UAA		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-2 chain		
 DLA-88 protein complex	DLA-88		locus	equivalent	MHC class I protein complex	dog	DLA-88 chain	Beta-2-microglobulin		
 DLA-88*03401 protein complex	DLA-88*03401		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*03401 chain	Beta-2-microglobulin		
 DLA-88*50101 protein complex	DLA-88*50101		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*50101 chain	Beta-2-microglobulin		

--- a/src/scripts/validate_templates.py
+++ b/src/scripts/validate_templates.py
@@ -85,7 +85,7 @@ def check_fields(
     reader,
     valid_labels,
     field_name="Parent",
-    top_term=None,
+    top_terms=None,
     source=None,
     required=True,
 ):
@@ -93,6 +93,8 @@ def check_fields(
     labels. If required, validate that this field value is filled in for all rows. Return a set of
     errors, if any."""
     global err_id
+    if not top_terms:
+        top_terms = []
     errors = []
     row_idx = 3
     headers = reader.fieldnames
@@ -119,7 +121,7 @@ def check_fields(
                     "instructions": f"add a '{field_name}' term",
                 }
             )
-        if value and value != top_term and value not in valid_labels:
+        if value and value not in top_terms and value not in valid_labels:
             err_id += 1
             errors.append(
                 {
@@ -213,6 +215,7 @@ def validate_chain(template_dir, labels, genetic_locus_labels, allow_missing):
 
     Return all the labels from this sheet and a set of errors, if any."""
     global err_id
+    # Add b2m locus (lives in core but can be used as gene only for b2m)
     table_name = "chain"
     errors = []
     with open(f"{template_dir}/{table_name}.tsv", "r") as f:
@@ -244,7 +247,7 @@ def validate_chain(template_dir, labels, genetic_locus_labels, allow_missing):
         next(reader)
 
         # Validate parents
-        parent_errors = check_fields(table_name, reader, chain_labels, top_term="protein")
+        parent_errors = check_fields(table_name, reader, chain_labels, top_terms=["protein"])
         errors.extend(parent_errors)
 
         # Reset file to beginning
@@ -260,6 +263,10 @@ def validate_chain(template_dir, labels, genetic_locus_labels, allow_missing):
             # Don't use check_fields because it is only required when parent == protein
             parent = row["Parent"]
             gene = row["Gene"]
+            if gene == "Beta-2-microglobulin locus" and row["Label"] == "Beta-2-microglobulin chain":
+                # exclude b2m from gene check
+                row_idx += 1
+                continue
             if not gene or gene.strip == "":
                 if parent == "protein":
                     err_id += 1
@@ -348,7 +355,7 @@ def validate_genetic_locus(template_dir, labels, external_labels, allow_missing)
         next(reader)
 
         # Validate parents
-        parent_errors = check_fields(table_name, reader, genetic_locus_labels, top_term="MHC locus")
+        parent_errors = check_fields(table_name, reader, genetic_locus_labels, top_terms=["Beta-2-microglobulin locus", "MHC locus"])
         errors.extend(parent_errors)
 
         # Reset file to beginning
@@ -423,7 +430,7 @@ def validate_halpotype(template_dir, labels, external_labels, allow_missing):
         next(reader)
         next(reader)
 
-        parent_errors = check_fields(table_name, reader, haplotype_labels, top_term="MHC haplotype")
+        parent_errors = check_fields(table_name, reader, haplotype_labels, top_terms=["MHC haplotype"])
         errors.extend(parent_errors)
 
         # Reset file to beginning
@@ -521,7 +528,7 @@ def validate_haplotype_molecule(
 
         # Validate parents (from molecule table)
         parent_errors = check_fields(
-            table_name, reader, molecule_labels, top_term="MHC protein complex", source="molecule",
+            table_name, reader, molecule_labels, top_terms=["MHC protein complex"], source="molecule",
         )
         errors.extend(parent_errors)
 
@@ -535,7 +542,7 @@ def validate_haplotype_molecule(
             table_name,
             reader,
             haplotype_labels,
-            top_term="MHC haplotype",
+            top_terms=["MHC haplotype"],
             field_name="With Haplotype",
             source="haplotype",
         )
@@ -669,7 +676,7 @@ def validate_molecule(
 
         # Validate parents
         parent_errors = check_fields(
-            table_name, reader, molecule_labels, top_term="MHC protein complex"
+            table_name, reader, molecule_labels, top_terms=["MHC protein complex"]
         )
         errors.extend(parent_errors)
 
@@ -700,7 +707,7 @@ def validate_molecule(
             reader,
             chain_labels,
             field_name="Beta Chain",
-            top_term="Beta-2-microglobulin",
+            top_terms=["Beta-2-microglobulin"],
             source="chain",
             required=False,
         )
@@ -839,7 +846,7 @@ def validate_mutant_molecule(template_dir, labels, external_labels, molecule_lab
 
         # Validate parents
         parent_errors = check_fields(
-            table_name, reader, mutant_molecule_labels, top_term="mutant MHC protein complex",
+            table_name, reader, mutant_molecule_labels, top_terms=["mutant MHC protein complex"],
         )
         errors.extend(parent_errors)
 
@@ -941,7 +948,7 @@ def validate_serotype(template_dir, labels, external_labels, allow_missing):
         next(reader)
 
         # Validate parents
-        parent_errors = check_fields(table_name, reader, serotype_labels, top_term="MHC serotype")
+        parent_errors = check_fields(table_name, reader, serotype_labels, top_terms=["MHC serotype"])
         errors.extend(parent_errors)
 
         # Reset file to beginning
@@ -1021,7 +1028,7 @@ def validate_serotype_molecule(
 
         # Validate parents (from molecule)
         parent_errors = check_fields(
-            table_name, reader, molecule_labels, top_term="MHC protein complex", source="molecule",
+            table_name, reader, molecule_labels, top_terms=["MHC protein complex"], source="molecule",
         )
         errors.extend(parent_errors)
 
@@ -1162,7 +1169,7 @@ def main():
         template_dir, labels, ext_labels, molecule_labels, serotype_labels, allow_missing
     )
 
-    # Add errors in tabel order
+    # Add errors in table order
     errors.extend(chain_errors)
     errors.extend(chain_sequence_errors)
     errors.extend(genetic_locus_errors)

--- a/src/scripts/validate_templates.py
+++ b/src/scripts/validate_templates.py
@@ -263,10 +263,6 @@ def validate_chain(template_dir, labels, genetic_locus_labels, allow_missing):
             # Don't use check_fields because it is only required when parent == protein
             parent = row["Parent"]
             gene = row["Gene"]
-            if gene == "Beta-2-microglobulin locus" and row["Label"] == "Beta-2-microglobulin chain":
-                # exclude b2m from gene check
-                row_idx += 1
-                continue
             if not gene or gene.strip == "":
                 if parent == "protein":
                     err_id += 1


### PR DESCRIPTION
"Ctid-UAA protein complex" renamed to "Ctid-UAA b2m-1-II protein complex" (MRO:0037013)

Addition of 6 new terms:
ID | Label
--- | ---
MRO:0037048 | grass carp Beta-2-microglobulin locus
MRO:0037049 | Beta-2-microglobulin locus
MRO:0037050 | grass carp Beta-2-microglobulin-1-II chain
MRO:0037051 | grass carp Beta-2-microglobulin-2 chain
MRO:0037052 | grass carp Beta-2-microglobulin chain
MRO:0037053 | Ctid-UAA b2m-2 protein complex

I also had to update the template validation script to handle the new b2m terms.