### PR TITLE
Update GO ID in queries

### DIFF
--- a/src/names.rq
+++ b/src/names.rq
@@ -8,7 +8,7 @@ PREFIX MRO:  <http://purl.obolibrary.org/obo/MRO_>
 SELECT ?subject ?nothing ?name
 WHERE {
   ?subject
-    rdfs:subClassOf* obo:GO_0043234 ;
+    rdfs:subClassOf* obo:GO_0032991 ;
     (obo:IAO_0000118 | obo:OBI_9991118 ) # alternative term | IEDB alternative term
       ?synonym .
   BIND(REPLACE(?synonym, " protein complex", "") AS ?name)

--- a/src/parents.rq
+++ b/src/parents.rq
@@ -11,18 +11,18 @@ WHERE {
   {
     # Manually describe the top-level nodes.
     VALUES (?subject ?parent ?label ?sort) {
-      (obo:GO_0043234 ""             "MHC"                 "")
-      (obo:GO_0042611 obo:GO_0043234 "MHC molecule"        "1")
-      (MRO:0000010    obo:GO_0043234 "haplotype"           "2")
-      (MRO:0000011    obo:GO_0043234 "serotype"            "3")
-      (MRO:0000012    obo:GO_0043234 "mutant MHC molecule" "4")
+      (obo:GO_0032991 ""             "MHC"                 "")
+      (obo:GO_0042611 obo:GO_0032991 "MHC molecule"        "1")
+      (MRO:0000010    obo:GO_0032991 "haplotype"           "2")
+      (MRO:0000011    obo:GO_0032991 "serotype"            "3")
+      (MRO:0000012    obo:GO_0032991 "mutant MHC molecule" "4")
     }
   }
   UNION
   {
-    # Now match all descendants of 'protein complex'.
+    # Now match all descendants of 'protein-containing complex'.
     ?subject
-      rdfs:subClassOf+ obo:GO_0043234 ; # protein complex
+      rdfs:subClassOf+ obo:GO_0032991 ; # protein-containing complex
       rdfs:subClassOf ?parent ;
       obo:OBI_9991118 ?label .
     OPTIONAL {

--- a/src/search.rq
+++ b/src/search.rq
@@ -20,7 +20,7 @@ SELECT DISTINCT
   ?namespace
 WHERE {
   ?subject
-    rdfs:subClassOf* obo:GO_0043234 ;
+    rdfs:subClassOf* obo:GO_0032991 ;
     rdfs:label ?label .
   OPTIONAL {
     ?subject MRO:has-iedb-mhc-id ?mhc_allele_restriction_id ;


### PR DESCRIPTION
Update `ALLELE_FINDER_*.csv` queries to replace `obo:GO_0043234` (obsolete) with `obo:GO_0032991` (protein-containing complex)