### PR TITLE
2021-01-14 Updates

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -489,7 +489,7 @@ HLA-DPA1*02:01/DPB1*01:01 protein complex	523	DP	300694	300697
 HLA-DQA1*05:05/DQB1*03:01 protein complex	524	DQ	300724	300728
 BoLA-DQA*003:01/DQB*004:02 protein complex	525	DQ	300436	300499
 BoLA-DQA*010:01:01/DQB*010:02:01 protein complex	526	DQ	300437	300501
-BoLA-DQA*012:01:01/DQB*10:05 protein complex	527	DQ	300482	300491
+BoLA-DQA*012:01/DQB*010:05 protein complex	527	DQ	300482	300491
 BoLA-DQA*022:01/DQB*012:01 protein complex	528	DQ	300483	300514
 BoLA-DQA*2206/DQB*014:02 protein complex	529	DQ		300504
 BoLA-DQA*2206/DQB*013:01 protein complex	530	DQ		300508
@@ -654,8 +654,8 @@ chicken MHC class I protein complex with B4 haplotype	724
 chicken MHC class I protein complex with B15 haplotype	725			
 chicken MHC class I protein complex with B19 haplotype	726			
 Eqca-N*00602 protein complex	727	N		
-BoLA-DQA*022:02:01/DQB*013:01 protein complex	728	DQ	300475	300508
-BoLA-DQA*022:02:01/DQB*009:01 protein complex	729	DQ	300475	300500
+BoLA-DQA*022:02/DQB*013:01 protein complex	728	DQ	300475	300508
+BoLA-DQA*022:02/DQB*009:01 protein complex	729	DQ	300475	300500
 HLA-DRB1*08:04 protein complex	734	DR		300771
 HLA-DQB1*03:19 protein complex	735	DQ		300829
 HLA-DRB1*04:11 protein complex	736	DR		300765
@@ -781,7 +781,7 @@ HLA-DPA1*01:03/DPB1*14:01 protein complex	872	DP
 Mamu-DRB*W006:02 protein complex	873	DR		
 BoLA-1*019:01 protein complex	874	1		
 BoLA-2*008:01 protein complex	875	2		
-BoLA-4*024:01:01:01 protein complex	876	4		
+BoLA-4*024:01 protein complex	876	4		
 Mamu-B*008:01 protein complex	877	B		
 HLA-B*39:24 protein complex	878	B		
 HLA-B*35:62 protein complex	879	B		
@@ -987,16 +987,16 @@ HLA-DPB1*15:01 protein complex	1079	DP
 HLA-DQA1*04:01 protein complex	1080	DQ		
 HLA-C*07:06 protein complex	1081	C		56585
 HLA-B*07:05 protein complex	1082	B		56585
-HLA-DPA1*02:01/ DPB1*13:01 protein complex	1083	DP	300694	300706
+HLA-DPA1*02:01/DPB1*13:01 protein complex	1083	DP	300694	300706
 HLA-DPA1*02:01/DPB1*10:01 protein complex	1084	DP	300694	
 rabbit MHC class I protein complex	1085			
 rabbit MHC class II protein complex	1086			
 RLA-A protein complex	1087	A		
 RLA-A*01 protein complex	1088	A		
 BoLA-DQA*010:01:01 protein complex	1089	DQ	300437	
-BoLA-DQA*012:01:01 protein complex	1090	DQ	300482	
+BoLA-DQA*012:01 protein complex	1090	DQ	300482	
 BoLA-DQA*022:01 protein complex	1091	DQ	300483	
-BoLA-DQA*022:02:01 protein complex	1092	DQ	300475	
+BoLA-DQA*022:02 protein complex	1092	DQ	300475	
 BoLA-DQB*004:02 protein complex	1093	DQ		300499
 BoLA-DQB*009:01 protein complex	1094	DQ		300500
 BoLA-DQB*010:02:01 protein complex	1095	DQ		300501

--- a/index.tsv
+++ b/index.tsv
@@ -371,15 +371,15 @@ MRO:0000367	BoLA-DQA chain	owl:Class
 MRO:0000368	BoLA-DQA*002:02 chain	owl:Class	
 MRO:0000369	BoLA-DQA*003:01 chain	owl:Class	
 MRO:0000370	BoLA-DQA*010:01:01 chain	owl:Class	
-MRO:0000371	BoLA-DQA*012:01:01 chain	owl:Class	
+MRO:0000371	BoLA-DQA*012:01 chain	owl:Class	
 MRO:0000372	BoLA-DQA*022:01 chain	owl:Class	
-MRO:0000373	BoLA-DQA*022:02:01 chain	owl:Class	
+MRO:0000373	BoLA-DQA*022:02 chain	owl:Class	
 MRO:0000374	BoLA-DQA*2206 chain	owl:Class	
 MRO:0000375	BoLA-DQB chain	owl:Class	
 MRO:0000376	BoLA-DQB*004:02 chain	owl:Class	
 MRO:0000377	BoLA-DQB*009:01 chain	owl:Class	
 MRO:0000378	BoLA-DQB*010:02:01 chain	owl:Class	
-MRO:0000379	BoLA-DQB*10051 chain	owl:Class	
+MRO:0000379	BoLA-DQB*010:05 chain	owl:Class	
 MRO:0000380	BoLA-DQB*012:01 chain	owl:Class	
 MRO:0000381	BoLA-DQB*013:01 chain	owl:Class	
 MRO:0000382	BoLA-DQB*014:02 chain	owl:Class	
@@ -398,7 +398,7 @@ MRO:0000394	BoLA-DRB3*015:02 chain	owl:Class
 MRO:0000395	BoLA-DRB3*020:02 chain	owl:Class	
 MRO:0000396	BoLA-DRB3*027:03 chain	owl:Class	
 MRO:0000397	BoLA-DRB3*030:01 chain	owl:Class	
-MRO:0000398	BoLA-DRB3*4501 chain	owl:Class	
+MRO:0000398	BoLA-DRB3*045:01 chain	owl:Class	
 MRO:0000399	BoLA-DRB6 chain	owl:Class	
 MRO:0000400	BoLA-MR1 chain	owl:Class	
 MRO:0000401	Caja-E chain	owl:Class	
@@ -939,10 +939,10 @@ MRO:0000935	BoLA-DQA*002:02 protein complex	owl:Class
 MRO:0000936	BoLA-DQA*003:01 protein complex	owl:Class	
 MRO:0000937	BoLA-DQA*003:01/DQB*004:02 protein complex	owl:Class	
 MRO:0000938	BoLA-DQA*010:01:01/DQB*010:02:01 protein complex	owl:Class	
-MRO:0000939	BoLA-DQA*012:01:01/DQB*10:05 protein complex	owl:Class	
+MRO:0000939	BoLA-DQA*012:01/DQB*010:05 protein complex	owl:Class	
 MRO:0000940	BoLA-DQA*022:01/DQB*012:01 protein complex	owl:Class	
-MRO:0000941	BoLA-DQA*022:02:01/DQB*009:01 protein complex	owl:Class	
-MRO:0000942	BoLA-DQA*022:02:01/DQB*013:01 protein complex	owl:Class	
+MRO:0000941	BoLA-DQA*022:02/DQB*009:01 protein complex	owl:Class	
+MRO:0000942	BoLA-DQA*022:02/DQB*013:01 protein complex	owl:Class	
 MRO:0000943	BoLA-DQA*2206/DQB*013:01 protein complex	owl:Class	
 MRO:0000944	BoLA-DQA*2206/DQB*014:02 protein complex	owl:Class	
 MRO:0000945	BoLA-DRB3 protein complex	owl:Class	
@@ -1879,8 +1879,8 @@ MRO:0001875	BoLA-2*008:01 chain	owl:Class
 MRO:0001876	BoLA-2*008:01 protein complex	owl:Class	
 MRO:0001877	BoLA-4 chain	owl:Class	
 MRO:0001878	BoLA-4 locus	owl:Class	
-MRO:0001879	BoLA-4*024:01:01:01 chain	owl:Class	
-MRO:0001880	BoLA-4*024:01:01:01 protein complex	owl:Class	
+MRO:0001879	BoLA-4*024:01 chain	owl:Class	
+MRO:0001880	BoLA-4*024:01 protein complex	owl:Class	
 MRO:0001881	BoLA-6*013:02 chain	owl:Class	
 MRO:0001882	BoLA-6*013:02 protein complex	owl:Class	
 MRO:0001883	BoLA-DRB3*010:01 chain	owl:Class	
@@ -2299,7 +2299,7 @@ MRO:0002295	HLA-C*07:06 chain	owl:Class
 MRO:0002296	HLA-B*07:05 chain	owl:Class	
 MRO:0002297	HLA-C*07:06 protein complex	owl:Class	
 MRO:0002298	HLA-B*07:05 protein complex	owl:Class	
-MRO:0002299	HLA-DPA1*02:01/ DPB1*13:01 protein complex	owl:Class	
+MRO:0002299	HLA-DPA1*02:01/DPB1*13:01 protein complex	owl:Class	
 MRO:0002300	HLA-DPA1*02:01/DPB1*10:01 protein complex	owl:Class	
 MRO:0002301	rabbit MHC class I locus	owl:Class	
 MRO:0002302	rabbit MHC class II locus	owl:Class	
@@ -2313,9 +2313,9 @@ MRO:0002309	rabbit MHC class II protein complex	owl:Class
 MRO:0002310	RLA-A protein complex	owl:Class	
 MRO:0002311	RLA-A*01 protein complex	owl:Class	
 MRO:0002312	BoLA-DQA*010:01:01 protein complex	owl:Class	
-MRO:0002313	BoLA-DQA*012:01:01 protein complex	owl:Class	
+MRO:0002313	BoLA-DQA*012:01 protein complex	owl:Class	
 MRO:0002314	BoLA-DQA*022:01 protein complex	owl:Class	
-MRO:0002315	BoLA-DQA*022:02:01 protein complex	owl:Class	
+MRO:0002315	BoLA-DQA*022:02 protein complex	owl:Class	
 MRO:0002316	BoLA-DQB*004:02 protein complex	owl:Class	
 MRO:0002317	BoLA-DQB*009:01 protein complex	owl:Class	
 MRO:0002318	BoLA-DQB*010:02:01 protein complex	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -110,7 +110,7 @@ BoLA-3*082:01 chain		subclass	BoLA-3 chain
 BoLA-3*083:01 chain		subclass	BoLA-3 chain		
 BoLA-3*087:01 chain		subclass	BoLA-3 chain		
 BoLA-4 chain		equivalent	protein	BoLA-4 locus	
-BoLA-4*024:01:01:01 chain		subclass	BoLA-4 chain		
+BoLA-4*024:01 chain		subclass	BoLA-4 chain		
 BoLA-4*024:02 chain		subclass	BoLA-4 chain		
 BoLA-4*063:01 chain		subclass	BoLA-4 chain		
 BoLA-4*076:01 chain		subclass	BoLA-4 chain		
@@ -160,7 +160,7 @@ BoLA-DQA*010:02 chain		subclass	BoLA-DQA chain
 BoLA-DQA*010:03 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*010:04 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*011:01 chain		subclass	BoLA-DQA chain		
-BoLA-DQA*012:01:01 chain		subclass	BoLA-DQA chain		
+BoLA-DQA*012:01 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*012:02 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*012:03 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*012:04 chain		subclass	BoLA-DQA chain		
@@ -175,7 +175,7 @@ BoLA-DQA*020:03 chain		subclass	BoLA-DQA chain
 BoLA-DQA*021:01 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*021:02 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*022:01 chain		subclass	BoLA-DQA chain		
-BoLA-DQA*022:02:01 chain		subclass	BoLA-DQA chain		
+BoLA-DQA*022:02 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*022:03 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*022:04 chain		subclass	BoLA-DQA chain		
 BoLA-DQA*022:05 chain		subclass	BoLA-DQA chain		
@@ -231,6 +231,7 @@ BoLA-DQB*009:03 chain		subclass	BoLA-DQB chain
 BoLA-DQB*010:01 chain		subclass	BoLA-DQB chain		
 BoLA-DQB*010:02:01 chain		subclass	BoLA-DQB chain		
 BoLA-DQB*010:03 chain		subclass	BoLA-DQB chain		
+BoLA-DQB*010:05 chain		subclass	BoLA-DQB chain		
 BoLA-DQB*010:06 chain		subclass	BoLA-DQB chain		
 BoLA-DQB*010:08 chain		subclass	BoLA-DQB chain		
 BoLA-DQB*010:09 chain		subclass	BoLA-DQB chain		
@@ -292,7 +293,6 @@ BoLA-DQB*039:01 chain		subclass	BoLA-DQB chain
 BoLA-DQB*040:01 chain		subclass	BoLA-DQB chain		
 BoLA-DQB*041:01 chain		subclass	BoLA-DQB chain		
 BoLA-DQB*042:01 chain		subclass	BoLA-DQB chain		
-BoLA-DQB*10051 chain		subclass	BoLA-DQB chain		
 BoLA-DRA chain		equivalent	protein	BoLA-DRA locus	
 BoLA-DRB3 chain		equivalent	protein	BoLA-DRB3 locus	
 BoLA-DRB3*001:01 chain		subclass	BoLA-DRB3 chain		
@@ -487,6 +487,7 @@ BoLA-DRB3*043:01 chain		subclass	BoLA-DRB3 chain
 BoLA-DRB3*043:02 chain		subclass	BoLA-DRB3 chain		
 BoLA-DRB3*043:03 chain		subclass	BoLA-DRB3 chain		
 BoLA-DRB3*044:01 chain		subclass	BoLA-DRB3 chain		
+BoLA-DRB3*045:01 chain		subclass	BoLA-DRB3 chain		
 BoLA-DRB3*046:01 chain		subclass	BoLA-DRB3 chain		
 BoLA-DRB3*047:01 chain		subclass	BoLA-DRB3 chain		
 BoLA-DRB3*048:01 chain		subclass	BoLA-DRB3 chain		
@@ -647,7 +648,6 @@ BoLA-DRB3*160:01 chain		subclass	BoLA-DRB3 chain
 BoLA-DRB3*161:01 chain		subclass	BoLA-DRB3 chain		
 BoLA-DRB3*162:01 chain		subclass	BoLA-DRB3 chain		
 BoLA-DRB3*163:01 chain		subclass	BoLA-DRB3 chain		
-BoLA-DRB3*4501 chain		subclass	BoLA-DRB3 chain		
 BoLA-DRB6 chain		equivalent	protein	BoLA-DRB6 locus	
 BoLA-DRB chain		equivalent	protein	BoLA-DRB locus	
 BoLA-MR1 chain		equivalent	protein	BoLA-MR1 locus	
@@ -9923,7 +9923,7 @@ HLA-C*03:280 chain		subclass	HLA-C chain
 HLA-C*03:281 chain		subclass	HLA-C chain		
 HLA-C*03:282 chain		subclass	HLA-C chain		
 HLA-C*03:283 chain		subclass	HLA-C chain		
-HLA-C*03:284 chain		subclass	HLA-C chain		
+HLA-C*03:284 chain		subclass	HLA-C chain		evidence of MHC chain expression not observed
 HLA-C*03:285 chain		subclass	HLA-C chain		
 HLA-C*03:286 chain		subclass	HLA-C chain		
 HLA-C*03:287 chain		subclass	HLA-C chain		

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -69,7 +69,7 @@ BoLA-2*088:01 protein complex	BoLA-2*088:01		complete molecule	equivalent	MHC cl
 BoLA-2*089:01 protein complex	BoLA-2*089:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-2*089:01 chain	Beta-2-microglobulin		
 BoLA-2*096:01 protein complex	BoLA-2*096:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-2*096:01 chain	Beta-2-microglobulin		
 BoLA-3 protein complex	BoLA-3		locus	equivalent	MHC class I protein complex	cattle	BoLA-3 chain	Beta-2-microglobulin		
-BoLA-3*001:01 protein complex	BoLA-3*001:01	N*00101|BoLA-3*00101	complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-3*001:01 chain	Beta-2-microglobulin		BoLA-A10 serotype
+BoLA-3*001:01 protein complex	BoLA-3*001:01	N*00101|BoLA-3*00101|BoLA-AW10	complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-3*001:01 chain	Beta-2-microglobulin		BoLA-A10 serotype
 BoLA-3*001:02 protein complex	BoLA-3*001:02		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-3*001:02 chain	Beta-2-microglobulin		
 BoLA-3*001:03 protein complex	BoLA-3*001:03		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-3*001:03 chain	Beta-2-microglobulin		
 BoLA-3*002:01 protein complex	BoLA-3*002:01	N*00201|BoLA-3*00201	complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-3*002:01 chain	Beta-2-microglobulin		BoLA-A10 serotype
@@ -110,7 +110,7 @@ BoLA-3*082:01 protein complex	BoLA-3*082:01		complete molecule	equivalent	MHC cl
 BoLA-3*083:01 protein complex	BoLA-3*083:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-3*083:01 chain	Beta-2-microglobulin		
 BoLA-3*087:01 protein complex	BoLA-3*087:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-3*087:01 chain	Beta-2-microglobulin		
 BoLA-4 protein complex	BoLA-4		locus	equivalent	MHC class I protein complex	cattle	BoLA-4 chain	Beta-2-microglobulin		
-BoLA-4*024:01:01:01 protein complex	BoLA-4*024:01:01:01	D18.1|BoLA-4*02401	complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-4*024:01:01:01 chain	Beta-2-microglobulin		
+BoLA-4*024:01 protein complex	BoLA-4*024:01	D18.1|BoLA-4*02401	complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-4*024:01 chain	Beta-2-microglobulin		
 BoLA-4*024:02 protein complex	BoLA-4*024:02		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-4*024:02 chain	Beta-2-microglobulin		
 BoLA-4*063:01 protein complex	BoLA-4*063:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-4*063:01 chain	Beta-2-microglobulin		
 BoLA-4*076:01 protein complex	BoLA-4*076:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-4*076:01 chain	Beta-2-microglobulin		
@@ -161,8 +161,8 @@ BoLA-DQA*010:02 protein complex	BoLA-DQA*010:02		partial molecule	equivalent	MHC
 BoLA-DQA*010:03 protein complex	BoLA-DQA*010:03		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*010:03 chain	BoLA-DQB chain		
 BoLA-DQA*010:04 protein complex	BoLA-DQA*010:04		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*010:04 chain	BoLA-DQB chain		
 BoLA-DQA*011:01 protein complex	BoLA-DQA*011:01		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*011:01 chain	BoLA-DQB chain		
-BoLA-DQA*012:01:01 protein complex	BoLA-DQA*012:01:01	BoLA-DQA*12011	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:01:01 chain	BoLA-DQB chain		
-BoLA-DQA*012:01:01/DQB*10:05 protein complex	BoLA-DQA*012:01:01/DQB*10051		complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:01:01 chain	BoLA-DQB*10051 chain		
+BoLA-DQA*012:01 protein complex	BoLA-DQA*012:01	BoLA-DQA*12011	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:01 chain	BoLA-DQB chain		
+BoLA-DQA*012:01/DQB*010:05 protein complex	BoLA-DQA*012:01/DQB*010:05		complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:01 chain	BoLA-DQB*010:05 chain		
 BoLA-DQA*012:02 protein complex	BoLA-DQA*012:02		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:02 chain	BoLA-DQB chain		
 BoLA-DQA*012:03 protein complex	BoLA-DQA*012:03		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:03 chain	BoLA-DQB chain		
 BoLA-DQA*012:04 protein complex	BoLA-DQA*012:04		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*012:04 chain	BoLA-DQB chain		
@@ -178,9 +178,9 @@ BoLA-DQA*021:01 protein complex	BoLA-DQA*021:01		partial molecule	equivalent	MHC
 BoLA-DQA*021:02 protein complex	BoLA-DQA*021:02		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*021:02 chain	BoLA-DQB chain		
 BoLA-DQA*022:01 protein complex	BoLA-DQA*022:01	BoLA-DQA*2201	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:01 chain	BoLA-DQB chain		
 BoLA-DQA*022:01/DQB*012:01 protein complex	BoLA-DQA*022:01/DQB*012:01	BoLA-DQA*2201/DQB*1201	complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:01 chain	BoLA-DQB*012:01 chain		
-BoLA-DQA*022:02:01 protein complex	BoLA-DQA*022:02:01	BoLA-DQA*2202	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:02:01 chain	BoLA-DQB chain		
-BoLA-DQA*022:02:01/DQB*009:01 protein complex	BoLA-DQA*022:02:01/DQB*009:01	BoLA-DQA*2202/DQB*0901	complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:02:01 chain	BoLA-DQB*009:01 chain		
-BoLA-DQA*022:02:01/DQB*013:01 protein complex	BoLA-DQA*022:02:01/DQB*013:01	BoLA-DQA*2202/DQB*1301	complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:02:01 chain	BoLA-DQB*013:01 chain		
+BoLA-DQA*022:02 protein complex	BoLA-DQA*022:02	BoLA-DQA*2202	partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:02 chain	BoLA-DQB chain		
+BoLA-DQA*022:02/DQB*009:01 protein complex	BoLA-DQA*022:02/DQB*009:01	BoLA-DQA*2202/DQB*0901	complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:02 chain	BoLA-DQB*009:01 chain		
+BoLA-DQA*022:02/DQB*013:01 protein complex	BoLA-DQA*022:02/DQB*013:01	BoLA-DQA*2202/DQB*1301	complete molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:02 chain	BoLA-DQB*013:01 chain		
 BoLA-DQA*022:03 protein complex	BoLA-DQA*022:03		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:03 chain	BoLA-DQB chain		
 BoLA-DQA*022:04 protein complex	BoLA-DQA*022:04		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:04 chain	BoLA-DQB chain		
 BoLA-DQA*022:05 protein complex	BoLA-DQA*022:05		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DQA*022:05 chain	BoLA-DQB chain		
@@ -491,7 +491,7 @@ BoLA-DRB3*043:01 protein complex	BoLA-DRB3*043:01		partial molecule	equivalent	M
 BoLA-DRB3*043:02 protein complex	BoLA-DRB3*043:02		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*043:02 chain		
 BoLA-DRB3*043:03 protein complex	BoLA-DRB3*043:03		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*043:03 chain		
 BoLA-DRB3*044:01 protein complex	BoLA-DRB3*044:01		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*044:01 chain		
-BoLA-DRB3*045:01 protein complex	BoLA-DRB3*4501		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*4501 chain		
+BoLA-DRB3*045:01 protein complex	BoLA-DRB3*045:01		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*045:01 chain		
 BoLA-DRB3*046:01 protein complex	BoLA-DRB3*046:01		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*046:01 chain		
 BoLA-DRB3*047:01 protein complex	BoLA-DRB3*047:01		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*047:01 chain		
 BoLA-DRB3*048:01 protein complex	BoLA-DRB3*048:01		partial molecule	equivalent	MHC class II protein complex	cattle	BoLA-DRA chain	BoLA-DRB3*048:01 chain		
@@ -12903,7 +12903,6 @@ HLA-DPA1*01:31 protein complex	HLA-DPA1*01:31		partial molecule	equivalent	MHC c
 HLA-DPA1*01:33 protein complex	HLA-DPA1*01:33		partial molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:33 chain	HLA-DPB chain		
 HLA-DPA1*01:34 protein complex	HLA-DPA1*01:34		partial molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:34 chain	HLA-DPB chain		
 HLA-DPA1*02:01 protein complex	HLA-DPA1*02:01	HLA-DPA1*020101	partial molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB chain		
-HLA-DPA1*02:01/ DPB1*13:01 protein complex	HLA-DPA1*02:01/ DPB1*13:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*13:01 chain		HLA-DP1 serotype
 HLA-DPA1*02:01/DPB1*01:01 protein complex	HLA-DPA1*02:01/DPB1*01:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*01:01 chain		HLA-DP1 serotype
 HLA-DPA1*02:01/DPB1*02:01 protein complex	HLA-DPA1*02:01/DPB1*02:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*02:01 chain		
 HLA-DPA1*02:01/DPB1*03:01 protein complex	HLA-DPA1*02:01/DPB1*03:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*03:01 chain		
@@ -12911,6 +12910,7 @@ HLA-DPA1*02:01/DPB1*04:01 protein complex	HLA-DPA1*02:01/DPB1*04:01		complete mo
 HLA-DPA1*02:01/DPB1*05:01 protein complex	HLA-DPA1*02:01/DPB1*05:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*05:01 chain		HLA-DP5 serotype
 HLA-DPA1*02:01/DPB1*09:01 protein complex	HLA-DPA1*02:01/DPB1*09:01	HLA-DPw9	complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*09:01 chain		HLA-DP9 serotype
 HLA-DPA1*02:01/DPB1*10:01 protein complex	HLA-DPA1*02:01/DPB1*10:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*10:01 chain		
+HLA-DPA1*02:01/DPB1*13:01 protein complex	HLA-DPA1*02:01/DPB1*13:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*13:01 chain		HLA-DP1 serotype
 HLA-DPA1*02:01/DPB1*14:01 protein complex	HLA-DPA1*02:01/DPB1*14:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*14:01 chain		
 HLA-DPA1*02:01/DPB1*17:01 protein complex	HLA-DPA1*02:01/DPB1*17:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:01 chain	HLA-DPB1*17:01 chain		
 HLA-DPA1*02:02 protein complex	HLA-DPA1*02:02		partial molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*02:02 chain	HLA-DPB chain		


### PR DESCRIPTION
removed extra digits from:
BoLA-4\*024:01:01:01
BoLA-DQA\*012:01:01
BoLA-DQA\*022:02:01

updated nomenclature for
DQB\*10051
BoLA-DRB3\*4501

added synonym for
BoLA-3\*00101

added expression for
HLA-C\*03:284 chain

removed extra space from
HLA-DPA1\*02:01/ DPB1\*13:01