### PR TITLE
2021-01-22 updates

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -157,7 +157,7 @@ horse MHC class I protein complex with A5 haplotype	160
 horse MHC class I protein complex with A6 haplotype	161			
 horse MHC class I protein complex with A9 haplotype	162			
 horse MHC class I protein complex with W11 haplotype	163			
-Gogo-B*0101 protein complex	164	B		
+Gogo-B*01:01 protein complex	164	B		
 mouse MHC class I protein complex with H2-a haplotype	165			
 mouse MHC class II protein complex with H2-a haplotype	166			
 mouse MHC class I protein complex with H2-b haplotype	167			
@@ -666,7 +666,7 @@ HLA-DRA*01:02/DRB1*13:01 protein complex	740	DR	300745	300782
 HLA-DRA*01:02/DRB3*01:01 protein complex	741	DR	300745	300801
 HLA-DRA*01:02/DRB3*02:02 protein complex	742	DR	300745	300803
 Gaga-BF2*004:01 protein complex	743	BF2		
-DLA-88*50801 protein complex	744	88		
+DLA-88*508:01 protein complex	744	88		
 HLA-B*44:27 protein complex	745	B	300823	56585
 HLA-DRB1*15:04 protein complex	746	DR		300798
 HLA-DRA*01:01 F54C mutant/DRB1*01:01 protein complex	747	DR		300746
@@ -774,7 +774,7 @@ HLA-C*12:04 protein complex	865	C
 HLA-B*15:18 protein complex	866	B		
 HLA-B*50:02 protein complex	867	B		
 HLA-A*01:03 protein complex	868	A		
-Eqca-1*00101 protein complex	869	1		
+Eqca-1*001:01 protein complex	869	1		
 Mamu-DPB1*07:01 protein complex	870	DP		
 HLA-DPA1*01:03/DPB1*20:01 protein complex	871	DP		
 HLA-DPA1*01:03/DPB1*14:01 protein complex	872	DP		
@@ -792,9 +792,9 @@ HLA-B*18:03 protein complex	883	B
 SLA-3*02:02 protein complex	884	3		
 HLA-DRB1*15:06 protein complex	885	DR		
 HLA-A*66:02 protein complex	886	A		
-Eqca-1*00201 protein complex	887	1		
-Eqca-16*00101 protein complex	888	16		
-Eqca-N*00101 protein complex	889	N		
+Eqca-1*002:01 protein complex	887	1		
+Eqca-16*001:01 protein complex	888	16		
+Eqca-N*001:01 protein complex	889	N		
 HLA-B*14:01 protein complex	890	B		
 Mamu-A1*007:01 protein complex	891	A	338360	
 Mamu-B*098 protein complex	892	B		
@@ -811,10 +811,10 @@ SLA-3*04:01 protein complex	902	3
 HLA-A*30:14L protein complex	903	A		
 BoLA-DRB3*010:01 protein complex	904	DRB3	344097	
 BoLA-DRB3*018:01 protein complex	905	DRB3	344098	
-Eqca-N*00601 protein complex	906	N	344099	
+Eqca-N*006:01 protein complex	906	N	344099	
 HLA protein complex with Cw18 serotype	907	C		
 HLA-DRB1*01:01 N82A mutant protein complex	908	DR		
-DLA-88*50101 protein complex	909	88		
+DLA-88*501:01 protein complex	909	88		
 rat CD1d protein complex	910	CD1	352098	
 H2-Qa-1b protein complex	911	Q1	352115	
 HLA-DPA1*01:03/DPB1*02:12 protein complex	912	DP		
@@ -864,7 +864,7 @@ Mamu-E*02:04 protein complex	955	E
 SLA-2 protein complex	956	2		
 HLA-B*44:09 protein complex	957	B		56585
 rhesus macaque MR1 protein complex	958	MR1		
-DLA-88*03401 protein complex	959	88		
+DLA-88*034:01 protein complex	959	88		
 HLA-C*08:03 protein complex	960	C		
 HLA-F*01:01 protein complex	961	F		56585
 Ptal-N*01:01 protein complex	962	N		
@@ -18339,3 +18339,4 @@ Mafa-A1 protein complex	18431	A1
 crab-eating macaque MHC class I protein complex	18432			
 crab-eating macaque MHC class II protein complex	18433			
 Ctid-UAA b2m-2 protein complex	18434			
+Anpl-UAA*SD protein complex		UAA		

--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -18339,4 +18339,4 @@ Mafa-A1 protein complex	18431	A1
 crab-eating macaque MHC class I protein complex	18432			
 crab-eating macaque MHC class II protein complex	18433			
 Ctid-UAA b2m-2 protein complex	18434			
-Anpl-UAA*SD protein complex		UAA		
+Anpl-UAA*SD protein complex	18435	UAA		

--- a/index.tsv
+++ b/index.tsv
@@ -404,11 +404,11 @@ MRO:0000400	BoLA-MR1 chain	owl:Class
 MRO:0000401	Caja-E chain	owl:Class	
 MRO:0000402	Caja-G chain	owl:Class	
 MRO:0000403	DLA-88 chain	owl:Class	
-MRO:0000404	DLA-88*50801 chain	owl:Class	
+MRO:0000404	DLA-88*508:01 chain	owl:Class	
 MRO:0000405	ELA-N chain	owl:Class	
 MRO:0000406	Eqca-N*00602 chain	owl:Class	
 MRO:0000407	Gogo-B chain	owl:Class	
-MRO:0000408	Gogo-B*0101 chain	owl:Class	
+MRO:0000408	Gogo-B*01:01 chain	owl:Class	
 MRO:0000409	obsolete H2-CD1 chain	owl:Class	true
 MRO:0000410	H2-D chain	owl:Class	
 MRO:0000411	H2-Db chain	owl:Class	
@@ -960,11 +960,11 @@ MRO:0000956	BoLA-DRB3*027:03 protein complex	owl:Class
 MRO:0000957	BoLA-DRB3*030:01 protein complex	owl:Class	
 MRO:0000958	BoLA-DRB3*045:01 protein complex	owl:Class	
 MRO:0000959	DLA-88 protein complex	owl:Class	
-MRO:0000960	DLA-88*50801 protein complex	owl:Class	
+MRO:0000960	DLA-88*508:01 protein complex	owl:Class	
 MRO:0000961	ELA-N protein complex	owl:Class	
 MRO:0000962	Eqca-N*00602 protein complex	owl:Class	
 MRO:0000963	Gogo-B protein complex	owl:Class	
-MRO:0000964	Gogo-B*0101 protein complex	owl:Class	
+MRO:0000964	Gogo-B*01:01 protein complex	owl:Class	
 MRO:0000965	H2-D protein complex	owl:Class	
 MRO:0000966	H2-Db protein complex	owl:Class	
 MRO:0000967	H2-Dd protein complex	owl:Class	
@@ -1892,14 +1892,14 @@ MRO:0001888	ELA-1 chain	owl:Class
 MRO:0001889	ELA-1 locus	owl:Class	
 MRO:0001890	ELA-16 chain	owl:Class	
 MRO:0001891	ELA-16 locus	owl:Class	
-MRO:0001892	Eqca-1*00101 chain	owl:Class	
-MRO:0001893	Eqca-1*00101 protein complex	owl:Class	
-MRO:0001894	Eqca-1*00201 chain	owl:Class	
-MRO:0001895	Eqca-1*00201 protein complex	owl:Class	
-MRO:0001896	Eqca-16*00101 chain	owl:Class	
-MRO:0001897	Eqca-16*00101 protein complex	owl:Class	
-MRO:0001898	Eqca-N*00101 chain	owl:Class	
-MRO:0001899	Eqca-N*00101 protein complex	owl:Class	
+MRO:0001892	Eqca-1*001:01 chain	owl:Class	
+MRO:0001893	Eqca-1*001:01 protein complex	owl:Class	
+MRO:0001894	Eqca-1*002:01 chain	owl:Class	
+MRO:0001895	Eqca-1*002:01 protein complex	owl:Class	
+MRO:0001896	Eqca-16*001:01 chain	owl:Class	
+MRO:0001897	Eqca-16*001:01 protein complex	owl:Class	
+MRO:0001898	Eqca-N*001:01 chain	owl:Class	
+MRO:0001899	Eqca-N*001:01 protein complex	owl:Class	
 MRO:0001900	HLA protein complex with A18 serotype	owl:Class	
 MRO:0001901	HLA protein complex with B64 serotype	owl:Class	
 MRO:0001902	HLA-A*01:03 chain	owl:Class	
@@ -1979,16 +1979,16 @@ MRO:0001975	SLA-3*02:02 chain	owl:Class
 MRO:0001976	SLA-3*02:02 protein complex	owl:Class	
 MRO:0001977	SLA-3*04:01 chain	owl:Class	
 MRO:0001978	SLA-3*04:01 protein complex	owl:Class	
-MRO:0001979	Eqca-N*00601 chain	owl:Class	
-MRO:0001980	Eqca-N*00601 protein complex	owl:Class	
+MRO:0001979	Eqca-N*006:01 chain	owl:Class	
+MRO:0001980	Eqca-N*006:01 protein complex	owl:Class	
 MRO:0001981	HLA-Cw18 serotype	owl:Class	
 MRO:0001982	HLA protein complex with Cw18 serotype	owl:Class	
 MRO:0001983	HLA-DRB1*01:01 N82A mutant protein complex	owl:Class	
 MRO:0001984	has MHC restriction level	owl:AnnotationProperty	
 MRO:0001985	has chain I mutation	owl:AnnotationProperty	
 MRO:0001986	has chain II mutation	owl:AnnotationProperty	
-MRO:0001987	DLA-88*50101 chain	owl:Class	
-MRO:0001988	DLA-88*50101 protein complex	owl:Class	
+MRO:0001987	DLA-88*501:01 chain	owl:Class	
+MRO:0001988	DLA-88*501:01 protein complex	owl:Class	
 MRO:0001989	rat non-classical MHC locus	owl:Class	
 MRO:0001990	rat CD1 locus	owl:Class	
 MRO:0001991	rat non-classical MHC chain	owl:Class	
@@ -2113,8 +2113,8 @@ MRO:0002109	Mamu-MR1 locus	owl:Class
 MRO:0002110	rhesus macaque non-classical MHC chain	owl:Class	
 MRO:0002111	Mamu-MR1 chain	owl:Class	
 MRO:0002112	Mamu-MR1 protein complex	owl:Class	
-MRO:0002113	DLA-88*03401 chain	owl:Class	
-MRO:0002114	DLA-88*03401 protein complex	owl:Class	
+MRO:0002113	DLA-88*034:01 chain	owl:Class	
+MRO:0002114	DLA-88*034:01 protein complex	owl:Class	
 MRO:0002115	rhesus macaque non-classical MHC protein complex	owl:Class	
 MRO:0002116	rhesus macaque MR1 chain	owl:Class	
 MRO:0002117	rhesus macaque MR1 protein complex	owl:Class	
@@ -37054,3 +37054,5 @@ MRO:0037050	grass carp Beta-2-microglobulin-1-II chain	owl:Class
 MRO:0037051	grass carp Beta-2-microglobulin-2 chain	owl:Class	
 MRO:0037052	grass carp Beta-2-microglobulin chain	owl:Class	
 MRO:0037053	Ctid-UAA b2m-2 protein complex	owl:Class	
+MRO:0037054	Anpl-UAA*SD protein complex	owl:Class	
+MRO:0037055	Anpl-UAA*SD chain	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -3,6 +3,7 @@ LABEL	A IAO:0000118 SPLIT=|	CLASS_TYPE	C %	C 'gene product of' some %	AI 'has ex
 Aime-128 chain		equivalent	protein	Aime-128 locus	
 Anpl-UAA chain		equivalent	protein	Anpl-UAA locus	
 Anpl-UAA*01 chain		subclass	Anpl-UAA chain		
+Anpl-UAA*SD chain		subclass	Anpl-UAA chain		
 BoLA-1 chain		equivalent	protein	BoLA-1 locus	
 BoLA-1*007:01 chain		subclass	BoLA-1 chain		
 BoLA-1*009:01 chain		subclass	BoLA-1 chain		
@@ -655,17 +656,17 @@ Caja-E chain		equivalent	protein	Caja-E locus
 Caja-G chain		equivalent	protein	Caja-G locus	
 Ctid-UAA chain		equivalent	protein	Ctid-UAA locus	
 DLA-88 chain		equivalent	protein	DLA-88 locus	
-DLA-88*03401 chain		subclass	DLA-88 chain		
-DLA-88*50101 chain		subclass	DLA-88 chain		
-DLA-88*50801 chain		subclass	DLA-88 chain		
+DLA-88*034:01 chain		subclass	DLA-88 chain		
+DLA-88*501:01 chain		subclass	DLA-88 chain		
+DLA-88*508:01 chain		subclass	DLA-88 chain		
 ELA-1 chain		equivalent	protein	ELA-1 locus	
 ELA-16 chain		equivalent	protein	ELA-16 locus	
 ELA-N chain		equivalent	protein	ELA-N locus	
-Eqca-1*00101 chain		subclass	ELA-1 chain		
-Eqca-1*00201 chain		subclass	ELA-1 chain		
-Eqca-16*00101 chain		subclass	ELA-16 chain		
-Eqca-N*00101 chain		subclass	ELA-N chain		
-Eqca-N*00601 chain		subclass	ELA-N chain		
+Eqca-1*001:01 chain		subclass	ELA-1 chain		
+Eqca-1*002:01 chain		subclass	ELA-1 chain		
+Eqca-16*001:01 chain		subclass	ELA-16 chain		
+Eqca-N*001:01 chain		subclass	ELA-N chain		
+Eqca-N*006:01 chain		subclass	ELA-N chain		
 Eqca-N*00602 chain		subclass	ELA-N chain		
 FLA-E chain		equivalent	protein	FLA-E locus	
 FLA-E*01801 chain		subclass	FLA-E chain		
@@ -682,7 +683,7 @@ Gaga-BF2*1301 chain		subclass	Gaga-BF2 chain
 Gaga-BF-B chain		equivalent	protein	Gaga-BF-B locus	
 Gaga-BF-YF chain		equivalent	protein	Gaga-BF-YF locus	
 Gogo-B chain		equivalent	protein	Gogo-B locus	
-Gogo-B*0101 chain		subclass	Gogo-B chain		
+Gogo-B*01:01 chain		subclass	Gogo-B chain		
 H2-D chain		equivalent	protein	H2-D locus	
 H2-Db chain		subclass	H2-D chain		
 H2-Dd chain		subclass	H2-D chain		

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -3,6 +3,7 @@ LABEL	A OBI:9991118	A IAO:0000118 SPLIT=|	A has MHC restriction level	CLASS_TYPE
 Aime-128 protein complex	Aime-128		locus	equivalent	MHC class I protein complex	giant panda	Aime-128 chain	Beta-2-microglobulin		
 Anpl-UAA protein complex	Anpl-UAA		locus	equivalent	MHC class I protein complex	duck	Anpl-UAA chain	Beta-2-microglobulin		
 Anpl-UAA*01 protein complex	Anpl-UAA*01		complete molecule	equivalent	MHC class I protein complex	duck	Anpl-UAA*01 chain	Beta-2-microglobulin		
+Anpl-UAA*SD protein complex	Anpl-UAA*SD		complete molecule	equivalent	MHC class I protein complex	duck	Anpl-UAA*SD chain	Beta-2-microglobulin		
 BoLA-1 protein complex	BoLA-1		locus	equivalent	MHC class I protein complex	cattle	BoLA-1 chain	Beta-2-microglobulin		
 BoLA-1*007:01 protein complex	BoLA-1*007:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-1*007:01 chain	Beta-2-microglobulin		
 BoLA-1*009:01 protein complex	BoLA-1*009:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-1*009:01 chain	Beta-2-microglobulin		
@@ -658,15 +659,15 @@ Caja-G protein complex	Caja-G		locus	equivalent	MHC class I protein complex	marm
 Ctid-UAA b2m-1-II protein complex	Ctid-UAA b2m-1-II		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-1-II chain		
 Ctid-UAA b2m-2 protein complex	Ctid-UAA b2m-2		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-2 chain		
 DLA-88 protein complex	DLA-88		locus	equivalent	MHC class I protein complex	dog	DLA-88 chain	Beta-2-microglobulin		
-DLA-88*03401 protein complex	DLA-88*03401		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*03401 chain	Beta-2-microglobulin		
-DLA-88*50101 protein complex	DLA-88*50101		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*50101 chain	Beta-2-microglobulin		
-DLA-88*50801 protein complex	DLA-88*50801	dla88-21	complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*50801 chain	Beta-2-microglobulin		
+DLA-88*034:01 protein complex	DLA-88*034:01		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*034:01 chain	Beta-2-microglobulin		
+DLA-88*501:01 protein complex	DLA-88*501:01		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*501:01 chain	Beta-2-microglobulin		
+DLA-88*508:01 protein complex	DLA-88*508:01	dla88-21	complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*508:01 chain	Beta-2-microglobulin		
 ELA-N protein complex	ELA-N		locus	equivalent	MHC class I protein complex	horse	ELA-N chain	Beta-2-microglobulin		
-Eqca-1*00101 protein complex	Eqca-1*00101	ELA-A3.1	complete molecule	equivalent	MHC class I protein complex	horse	Eqca-1*00101 chain	Beta-2-microglobulin	A3 haplotype	
-Eqca-1*00201 protein complex	Eqca-1*00201		complete molecule	equivalent	MHC class I protein complex	horse	Eqca-1*00201 chain	Beta-2-microglobulin		
-Eqca-16*00101 protein complex	Eqca-16*00101		complete molecule	equivalent	MHC class I protein complex	horse	Eqca-16*00101 chain	Beta-2-microglobulin		
-Eqca-N*00101 protein complex	Eqca-N*00101		complete molecule	equivalent	MHC class I protein complex	horse	Eqca-N*00101 chain	Beta-2-microglobulin		
-Eqca-N*00601 protein complex	Eqca-N*00601	MHC I 1 14 allele, 7-6	complete molecule	equivalent	MHC class I protein complex	horse	Eqca-N*00601 chain	Beta-2-microglobulin		
+Eqca-1*001:01 protein complex	Eqca-1*001:01	ELA-A3.1	complete molecule	equivalent	MHC class I protein complex	horse	Eqca-1*001:01 chain	Beta-2-microglobulin	A3 haplotype	
+Eqca-1*002:01 protein complex	Eqca-1*002:01		complete molecule	equivalent	MHC class I protein complex	horse	Eqca-1*002:01 chain	Beta-2-microglobulin		
+Eqca-16*001:01 protein complex	Eqca-16*001:01		complete molecule	equivalent	MHC class I protein complex	horse	Eqca-16*001:01 chain	Beta-2-microglobulin		
+Eqca-N*001:01 protein complex	Eqca-N*001:01		complete molecule	equivalent	MHC class I protein complex	horse	Eqca-N*001:01 chain	Beta-2-microglobulin		
+Eqca-N*006:01 protein complex	Eqca-N*006:01	MHC I 1 14 allele, 7-6	complete molecule	equivalent	MHC class I protein complex	horse	Eqca-N*006:01 chain	Beta-2-microglobulin		
 Eqca-N*00602 protein complex	Eqca-N*00602	A1*7-6	complete molecule	equivalent	MHC class I protein complex	horse	Eqca-N*00602 chain	Beta-2-microglobulin	A1 haplotype	
 FLA-E protein complex	FLA-E		locus	equivalent	MHC class I protein complex	cat	FLA-E chain	Beta-2-microglobulin		
 FLA-E*01801 protein complex	FLA-E*01801	FLA-B*n06	complete molecule	equivalent	MHC class I protein complex	cat	FLA-E*01801 chain	Beta-2-microglobulin		
@@ -681,7 +682,7 @@ Gaga-BF2*015:01 protein complex	Gaga-BF2*015:01	BF2*1501|BF2*015:01|BFIV15	compl
 Gaga-BF2*021:01 protein complex	Gaga-BF2*021:01	BF2*2101|BF2*021:01|BFIV21|BF2*131|BF2*W1|BFCC2a|BFCC15-1	complete molecule	equivalent	MHC class I protein complex	chicken	Gaga-BF2*021:01 chain	Beta-2-microglobulin	B21 haplotype	
 Gaga-BF2*1301 protein complex	Gaga-BF2*1301		complete molecule	equivalent	MHC class I protein complex	chicken	Gaga-BF2*1301 chain	Beta-2-microglobulin	B13 haplotype	
 Gogo-B protein complex	Gogo-B		locus	equivalent	MHC class I protein complex	gorilla	Gogo-B chain	Beta-2-microglobulin		
-Gogo-B*0101 protein complex	Gogo-B*0101		complete molecule	equivalent	MHC class I protein complex	gorilla	Gogo-B*0101 chain	Beta-2-microglobulin		
+Gogo-B*01:01 protein complex	Gogo-B*01:01		complete molecule	equivalent	MHC class I protein complex	gorilla	Gogo-B*01:01 chain	Beta-2-microglobulin		
 H2-D protein complex	H2-D		locus	equivalent	MHC class I protein complex	mouse	H2-D chain	Beta-2-microglobulin		
 H2-Db protein complex	H2-Db		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Db chain	Beta-2-microglobulin	H2-b haplotype	
 H2-Dd protein complex	H2-Dd		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Dd chain	Beta-2-microglobulin	H2-d haplotype	


### PR DESCRIPTION
Updates from @rvita:
1) added new duck term Anpl-UAA*SD
2) updated dog (DLA) nomenclature & chain sequences
2) updated horse (Eqca) nomenclature & chain sequences (note 1 left unchanged on purpose)
3) updated gorilla (Gogo) nomenclature & chain sequences

The Travis builds are always going to fail since https://build.obolibrary.io/ is down - we can update to use a released ROBOT JAR once v1.8.0 is released, since we're using some unreleased features for TDB. Running `make test` locally passes.