### PR TITLE
Update 2021-03-03

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -18342,3 +18342,4 @@ Ctid-UAA b2m-2 protein complex	18434
 Anpl-UAA*SD protein complex	18435	UAA		
 rhesus macaque CD1b protein complex	18436	CD1		
 rhesus macaque CD1c protein complex	18437	CD1		
+mouse CD1d Y73H mutant protein complex	18438	CD1		

--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -18340,3 +18340,5 @@ crab-eating macaque MHC class I protein complex	18432
 crab-eating macaque MHC class II protein complex	18433			
 Ctid-UAA b2m-2 protein complex	18434			
 Anpl-UAA*SD protein complex	18435	UAA		
+rhesus macaque CD1b protein complex	18436	CD1		
+rhesus macaque CD1c protein complex	18437	CD1		

--- a/index.tsv
+++ b/index.tsv
@@ -37056,3 +37056,9 @@ MRO:0037052	grass carp Beta-2-microglobulin chain	owl:Class
 MRO:0037053	Ctid-UAA b2m-2 protein complex	owl:Class	
 MRO:0037054	Anpl-UAA*SD protein complex	owl:Class	
 MRO:0037055	Anpl-UAA*SD chain	owl:Class	
+MRO:0037056	Mamu-CD1 locus	owl:Class	
+MRO:0037057	rhesus macaque CD1b chain	owl:Class	
+MRO:0037058	rhesus macaque CD1c chain	owl:Class	
+MRO:0037059	Mamu-CD1 chain	owl:Class	
+MRO:0037060	rhesus macaque CD1b protein complex	owl:Class	
+MRO:0037061	rhesus macaque CD1c protein complex	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -17900,6 +17900,7 @@ Mamu-B*083:01 chain		subclass	Mamu-B chain
 Mamu-B*087:01 chain		subclass	Mamu-B chain		
 Mamu-B*090:01 chain		subclass	Mamu-B chain		
 Mamu-B*098 chain		subclass	Mamu-B chain		
+Mamu-CD1 chain		equivalent	protein	Mamu-CD1 locus	
 Mamu-DPA chain		equivalent	protein	Mamu-DPA locus	
 Mamu-DPB1*01:01 chain		subclass	Mamu-DPB chain		
 Mamu-DPB1*07:01 chain		subclass	Mamu-DPB chain		
@@ -18097,6 +18098,8 @@ rat CD1d chain		subclass	rat CD1 chain
 rat MHC class I chain		equivalent	protein	rat MHC class I locus	
 rat MHC class II chain		equivalent	protein	rat MHC class II locus	
 rat non-classical MHC chain		equivalent	protein	rat non-classical MHC locus	
+rhesus macaque CD1b chain		subclass	Mamu-CD1 chain		
+rhesus macaque CD1c chain		subclass	Mamu-CD1 chain		
 rhesus macaque MHC class I chain		equivalent	protein	rhesus macaque MHC class I locus	
 rhesus macaque MHC class II chain		equivalent	protein	rhesus macaque MHC class II locus	
 rhesus macaque MR1 chain		subclass	Mamu-MR1 chain		

--- a/ontology/genetic-locus.tsv
+++ b/ontology/genetic-locus.tsv
@@ -69,6 +69,7 @@ Mafa-DRA locus		subclass	crab-eating macaque MHC class II locus
 Mafa-DRB locus		subclass	crab-eating macaque MHC class II locus	
 Mamu-A locus		subclass	rhesus macaque MHC class I locus	
 Mamu-B locus		subclass	rhesus macaque MHC class I locus	
+Mamu-CD1 locus		subclass	rhesus macaque non-classical MHC locus	
 Mamu-DPA locus		subclass	rhesus macaque MHC class II locus	
 Mamu-DPB locus		subclass	rhesus macaque MHC class II locus	
 Mamu-DRA locus		subclass	rhesus macaque MHC class II locus	

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -18166,6 +18166,8 @@ rat CD1d protein complex	rat CD1d	rCD1d	complete molecule	equivalent	non-classic
 rat MHC class I protein complex	rat		class	equivalent	MHC class I protein complex	rat				
 rat MHC class II protein complex	rat		class	equivalent	MHC class II protein complex	rat				
 rat non-classical MHC protein complex	rat		class	equivalent	non-classical MHC protein complex	rat				
+rhesus macaque CD1b protein complex	rhesus macaque CD1b	Mamu CD1b	complete molecule	equivalent	non-classical MHC protein complex	rhesus macaque	rhesus macaque CD1b chain	Beta-2-microglobulin		
+rhesus macaque CD1c protein complex	rhesus macaque CD1c	Mamu CD1c	complete molecule	equivalent	non-classical MHC protein complex	rhesus macaque	rhesus macaque CD1c chain	Beta-2-microglobulin		
 rhesus macaque MHC class I protein complex	rhesus macaque		class	equivalent	MHC class I protein complex	rhesus macaque				
 rhesus macaque MHC class I protein complex	rhesus macaque		class	equivalent	MHC class I protein complex	rhesus macaque				
 rhesus macaque MHC class II protein complex	rhesus macaque		class	equivalent	MHC class II protein complex	rhesus macaque				


### PR DESCRIPTION
This update includes 6 new terms:

ID | Label
--- | ---
MRO:0037056 | Mamu-CD1 locus
MRO:0037057 | rhesus macaque CD1b chain
MRO:0037058 | rhesus macaque CD1c chain
MRO:0037059 | Mamu-CD1 chain
MRO:0037060 | rhesus macaque CD1b protein complex
MRO:0037061 | rhesus macaque CD1c protein complex