### PR TITLE
2021-03-29 update

### DIFF
--- a/index.tsv
+++ b/index.tsv
@@ -45937,3 +45937,7 @@ MRO:0045933	BoLA-NC2*001:02 protein complex	owl:Class
 MRO:0045934	BoLA-5*072:01 protein complex	owl:Class	
 MRO:0045935	BoLA-NC1*012:01 protein complex	owl:Class	
 MRO:0045936	BoLA-NC2*001:01 protein complex	owl:Class	
+MRO:0045939	Patr-B*01:02 chain	owl:Class	
+MRO:0045940	Patr-B*01:02 protein complex	owl:Class	
+MRO:0045941	obsolete SLA-6*01:02 chain	owl:Class	true
+MRO:0045942	obsolete SLA-6*01:02 protein complex	owl:Class	true

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -18216,7 +18216,7 @@ Mamu-A3*13:12 chain		subclass	Mamu-A chain
 Mamu-A3*13:13 chain		subclass	Mamu-A chain		
 Mamu-A3*13:14 chain		subclass	Mamu-A chain		
 Mamu-A4*01:01 chain		subclass	Mamu-A chain		
-Mamu-A4*01:02 chain		subclass	Mamu-A chain		
+Mamu-A4*01:02 chain		subclass	Mamu-A chain		evidence of MHC chain expression not observed
 Mamu-A4*01:03 chain		subclass	Mamu-A chain		
 Mamu-A4*02:02 chain		subclass	Mamu-A chain		
 Mamu-A4*02:03 chain		subclass	Mamu-A chain		
@@ -19310,6 +19310,7 @@ Patr-AL*01:03 chain		subclass	Patr-AL chain
 Patr-AL*01:04 chain		subclass	Patr-AL chain		
 Patr-B chain		equivalent	protein	Patr-B locus	
 Patr-B*01:01 chain		subclass	Patr-B chain		
+Patr-B*01:02 chain		subclass	Patr-B chain		evidence of MHC chain expression not observed
 Patr-B*02:01 chain		subclass	Patr-B chain		
 Patr-B*02:03 chain		subclass	Patr-B chain		
 Patr-B*03:01 chain		subclass	Patr-B chain		
@@ -19830,6 +19831,7 @@ SLA-3*07:03 chain		subclass	SLA-3 chain
 SLA-3*08:01 chain		subclass	SLA-3 chain		
 SLA-6 chain		equivalent	protein	SLA-6 locus	
 SLA-6*01:01 chain		subclass	SLA-6 chain		
+SLA-6*01:02 chain		subclass	SLA-6 chain		
 SLA-6*02:01 chain		subclass	SLA-6 chain		
 SLA-6*03:01 chain		subclass	SLA-6 chain		
 SLA-6*04:01 chain		subclass	SLA-6 chain		

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -24256,6 +24256,7 @@ Patr-AL*01:03 protein complex	Patr-AL*01:03		complete molecule	equivalent	non-cl
 Patr-AL*01:04 protein complex	Patr-AL*01:04		complete molecule	equivalent	non-classical MHC protein complex	chimpanzee	Patr-AL*01:04 chain	Beta-2-microglobulin		
 Patr-B protein complex	Patr-B		locus	equivalent	MHC class I protein complex	chimpanzee	Patr-B chain	Beta-2-microglobulin		
 Patr-B*01:01 protein complex	Patr-B*01:01		complete molecule	equivalent	MHC class I protein complex	chimpanzee	Patr-B*01:01 chain	Beta-2-microglobulin		
+Patr-B*01:02 protein complex	Patr-B*01:02		complete molecule	equivalent	MHC class I protein complex	chimpanzee	Patr-B*01:02 chain	Beta-2-microglobulin		
 Patr-B*02:01 protein complex	Patr-B*02:01		complete molecule	equivalent	MHC class I protein complex	chimpanzee	Patr-B*02:01 chain	Beta-2-microglobulin		
 Patr-B*02:03 protein complex	Patr-B*02:03		complete molecule	equivalent	MHC class I protein complex	chimpanzee	Patr-B*02:03 chain	Beta-2-microglobulin		
 Patr-B*03:01 protein complex	Patr-B*03:01		complete molecule	equivalent	MHC class I protein complex	chimpanzee	Patr-B*03:01 chain	Beta-2-microglobulin		
@@ -24758,6 +24759,7 @@ SLA-3*07:02 protein complex	SLA-3*07:02		complete molecule	equivalent	MHC class 
 SLA-3*07:03 protein complex	SLA-3*07:03		complete molecule	equivalent	MHC class I protein complex	pig	SLA-3*07:03 chain	Beta-2-microglobulin		
 SLA-3*08:01 protein complex	SLA-3*08:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-3*08:01 chain	Beta-2-microglobulin		
 SLA-6*01:01 protein complex	SLA-6*01:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*01:01 chain	Beta-2-microglobulin		
+SLA-6*01:02 protein complex	SLA-6*01:02		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*01:02 chain	Beta-2-microglobulin		
 SLA-6*02:01 protein complex	SLA-6*02:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*02:01 chain	Beta-2-microglobulin		
 SLA-6*03:01 protein complex	SLA-6*03:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*03:01 chain	Beta-2-microglobulin		
 SLA-6*04:01 protein complex	SLA-6*04:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*04:01 chain	Beta-2-microglobulin		


### PR DESCRIPTION
Four new terms (two of which are obsolete):
ID | Label
--- | ---
MRO:0045939 | Patr-B*01:02 chain
MRO:0045940 | Patr-B*01:02 protein complex	
MRO:0045941 | obsolete SLA-6*01:02 chain
MRO:0045942 | obsolete SLA-6*01:02 protein complex

Other changes:
* Removed duplicate "HLA-DQA1*01:04 chain"
* Updated "Mamu-A4*01:02 chain"