### PR TITLE
Remove logic from obsolete terms

### DIFF
--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -19831,7 +19831,6 @@ SLA-3*07:03 chain		subclass	SLA-3 chain
 SLA-3*08:01 chain		subclass	SLA-3 chain		
 SLA-6 chain		equivalent	protein	SLA-6 locus	
 SLA-6*01:01 chain		subclass	SLA-6 chain		
-SLA-6*01:02 chain		subclass	SLA-6 chain		
 SLA-6*02:01 chain		subclass	SLA-6 chain		
 SLA-6*03:01 chain		subclass	SLA-6 chain		
 SLA-6*04:01 chain		subclass	SLA-6 chain		

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -24759,7 +24759,6 @@ SLA-3*07:02 protein complex	SLA-3*07:02		complete molecule	equivalent	MHC class 
 SLA-3*07:03 protein complex	SLA-3*07:03		complete molecule	equivalent	MHC class I protein complex	pig	SLA-3*07:03 chain	Beta-2-microglobulin		
 SLA-3*08:01 protein complex	SLA-3*08:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-3*08:01 chain	Beta-2-microglobulin		
 SLA-6*01:01 protein complex	SLA-6*01:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*01:01 chain	Beta-2-microglobulin		
-SLA-6*01:02 protein complex	SLA-6*01:02		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*01:02 chain	Beta-2-microglobulin		
 SLA-6*02:01 protein complex	SLA-6*02:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*02:01 chain	Beta-2-microglobulin		
 SLA-6*03:01 protein complex	SLA-6*03:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*03:01 chain	Beta-2-microglobulin		
 SLA-6*04:01 protein complex	SLA-6*04:01		complete molecule	equivalent	MHC class I protein complex	pig	SLA-6*04:01 chain	Beta-2-microglobulin		


### PR DESCRIPTION
Two obsolete terms were created recently, but they did not have the "obsolete" appended to their labels in `chain` and `molecule`. These terms should not be in these files, anyway, as obsolete terms should not have logic.

I've confirmed that `make clean test` passes.