### PR TITLE
Fail on error-level messages in validate_template

### DIFF
--- a/src/scripts/validate_templates.py
+++ b/src/scripts/validate_templates.py
@@ -1,5 +1,6 @@
 import csv
 import re
+import sys
 
 from argparse import ArgumentParser
 
@@ -1197,6 +1198,7 @@ def main():
         writer.writerows(errors)
 
     if errors:
+        has_error_level = [x for x in errors if x["level"] == "error"]
         msg = create_message(errors)
         print(
             "\n-------------------------------------------------------\n"
@@ -1204,6 +1206,9 @@ def main():
             f"\n{msg}\n"
             "---------------------------------------------------------\n"
         )
+        if has_error_level:
+            # fail if any "error" level errors were returned
+            sys.exit(1)
     else:
         print("\nValidation passed!\n")
 


### PR DESCRIPTION
Currently, "error"-level messages just print a warning but do not cause the `make` process to fail. This fixes that issue.