### PR TITLE
2021-05-03 update

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -524,7 +524,7 @@ H2-Kb Y84C mutant protein complex	565	K
 HLA-E*01:03 protein complex	566	E	300812	56585
 HLA-DRB1*04:01 Q110N, K139T mutant protein complex	567	DR		
 H2-Kb D77S, K89A mutant protein complex	569	K		
-sheep MHC class I protein complex	570			
+domestic sheep MHC class I protein complex	570			
 HLA protein complex with A34 serotype	571	A		
 HLA protein complex with A74 serotype	572	A		
 HLA protein complex with A80 serotype	573	A		
@@ -757,7 +757,7 @@ Gaga-BF2*014:01 protein complex	848	BF2
 Gaga-BF1*002:01 protein complex	849	BF1		
 HLA-B*44:28 protein complex	850	B		
 dog MHC class I protein complex	851			
-sheep MHC class II protein complex	852			
+domestic sheep MHC class II protein complex	852			
 HLA-DQA1*03:02/DQB1*03:01 protein complex	853	DQ		
 HLA-B*39:09 protein complex	854	B		
 HLA-B*27:08 protein complex	855	B		

--- a/index.tsv
+++ b/index.tsv
@@ -124,8 +124,8 @@ MRO:0000120	rat MHC class I locus	owl:Class
 MRO:0000121	rat MHC class II locus	owl:Class	
 MRO:0000122	rhesus macaque MHC class I locus	owl:Class	
 MRO:0000123	rhesus macaque MHC class II locus	owl:Class	
-MRO:0000124	sheep MHC class I locus	owl:Class	
-MRO:0000125	sheep MHC class II locus	owl:Class	
+MRO:0000124	domestic sheep MHC class I locus	owl:Class	
+MRO:0000125	domestic sheep MHC class II locus	owl:Class	
 MRO:0000126	A1 haplotype	owl:Class	
 MRO:0000127	A3 haplotype	owl:Class	
 MRO:0000128	A4 haplotype	owl:Class	
@@ -910,8 +910,8 @@ MRO:0000906	rat MHC class I chain	owl:Class
 MRO:0000907	rat MHC class II chain	owl:Class	
 MRO:0000908	rhesus macaque MHC class I chain	owl:Class	
 MRO:0000909	rhesus macaque MHC class II chain	owl:Class	
-MRO:0000910	sheep MHC class I chain	owl:Class	
-MRO:0000911	sheep MHC class II chain	owl:Class	
+MRO:0000910	domestic sheep MHC class I chain	owl:Class	
+MRO:0000911	domestic sheep MHC class II chain	owl:Class	
 MRO:0000912	Gaga-BF1 protein complex	owl:Class	
 MRO:0000913	Gaga-BF2 protein complex	owl:Class	
 MRO:0000914	Gaga-BF1*002:01 protein complex	owl:Class	
@@ -1853,8 +1853,8 @@ MRO:0001849	Saoe-G*02 serotype	owl:Class
 MRO:0001850	Saoe-G*04 serotype	owl:Class	
 MRO:0001851	Saoe-G*08 serotype	owl:Class	
 MRO:0001852	Saoe-G*12 serotype	owl:Class	
-MRO:0001853	sheep MHC class I protein complex	owl:Class	
-MRO:0001854	sheep MHC class II protein complex	owl:Class	
+MRO:0001853	domestic sheep MHC class I protein complex	owl:Class	
+MRO:0001854	domestic sheep MHC class II protein complex	owl:Class	
 MRO:0001855	chicken MHC class I protein complex with B4 haplotype	owl:Class	
 MRO:0001856	chicken MHC class I protein complex with B12 haplotype	owl:Class	
 MRO:0001857	chicken MHC class I protein complex with B15 haplotype	owl:Class	
@@ -45944,3 +45944,11 @@ MRO:0045942	obsolete SLA-6*01:02 protein complex	owl:Class	true
 MRO:0045943	SLA-6 protein complex	owl:Class	
 MRO:0045944	SLA-DQ protein complex	owl:Class	
 MRO:0045945	Mamu-DQ protein complex	owl:Class	
+MRO:0045946	rainbow trout MHC class I protein complex	owl:Class	
+MRO:0045947	atlantic salmon MHC class I protein complex	owl:Class	
+MRO:0045948	bighorn sheep MHC class I protein complex	owl:Class	
+MRO:0045949	goat MHC class I protein complex	owl:Class	
+MRO:0045950	rainbow trout MHC class II protein complex	owl:Class	
+MRO:0045951	atlantic salmon MHC class II protein complex	owl:Class	
+MRO:0045952	bighorn sheep MHC class II protein complex	owl:Class	
+MRO:0045953	goat MHC class II protein complex	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -6833,7 +6833,7 @@ HLA-B*35:454 chain		subclass	HLA-B chain
 HLA-B*35:455 chain		subclass	HLA-B chain		
 HLA-B*35:457 chain		subclass	HLA-B chain		
 HLA-B*35:458 chain		subclass	HLA-B chain		
-HLA-B*35:460 chain		subclass	HLA-B chain		
+HLA-B*35:460 chain		subclass	HLA-B chain		evidence of MHC chain expression questionable
 HLA-B*35:462 chain		subclass	HLA-B chain		
 HLA-B*35:463 chain		subclass	HLA-B chain		
 HLA-B*35:464 chain		subclass	HLA-B chain		
@@ -10241,7 +10241,7 @@ HLA-C*04:56 chain		subclass	HLA-C chain
 HLA-C*04:57 chain		subclass	HLA-C chain		
 HLA-C*04:58 chain		subclass	HLA-C chain		
 HLA-C*04:60 chain		subclass	HLA-C chain		
-HLA-C*04:61 chain		subclass	HLA-C chain		
+HLA-C*04:61 chain		subclass	HLA-C chain		evidence of MHC chain expression not observed
 HLA-C*04:62 chain		subclass	HLA-C chain		
 HLA-C*04:63 chain		subclass	HLA-C chain		
 HLA-C*04:64 chain		subclass	HLA-C chain		
@@ -14036,7 +14036,7 @@ HLA-DQA1*01:04 chain		subclass	HLA-DQA chain
 HLA-DQA1*01:04 chain		subclass	HLA-DQA chain		
 HLA-DQA1*01:05 chain		subclass	HLA-DQA chain		
 HLA-DQA1*01:06 chain		subclass	HLA-DQA chain		
-HLA-DQA1*01:07 chain		subclass	HLA-DQA chain		
+HLA-DQA1*01:07 chain		subclass	HLA-DQA chain		evidence of MHC chain expression questionable
 HLA-DQA1*01:08 chain		subclass	HLA-DQA chain		
 HLA-DQA1*01:09 chain		subclass	HLA-DQA chain		
 HLA-DQA1*01:10 chain		subclass	HLA-DQA chain		
@@ -20063,6 +20063,8 @@ crab-eating macaque MHC class I chain		equivalent	protein	crab-eating macaque MH
 crab-eating macaque MHC class II chain		equivalent	protein	crab-eating macaque MHC class II locus	
 dog MHC class I chain		equivalent	protein	dog MHC class I locus	
 dog MHC class II chain		equivalent	protein	dog MHC class II locus	
+domestic sheep MHC class I chain		equivalent	protein	domestic sheep MHC class I locus	
+domestic sheep MHC class II chain		equivalent	protein	domestic sheep MHC class II locus	
 duck MHC class I chain		equivalent	protein	duck MHC class I locus	
 giant panda MHC class I chain		equivalent	protein	giant panda MHC class I locus	
 giant panda MHC class II chain		equivalent	protein	giant panda MHC class II locus	
@@ -20108,5 +20110,3 @@ rhesus macaque MHC class I chain		equivalent	protein	rhesus macaque MHC class I 
 rhesus macaque MHC class II chain		equivalent	protein	rhesus macaque MHC class II locus	
 rhesus macaque MR1 chain		subclass	Mamu-MR1 chain		
 rhesus macaque non-classical MHC chain		equivalent	protein	rhesus macaque non-classical MHC locus	
-sheep MHC class I chain		equivalent	protein	sheep MHC class I locus	
-sheep MHC class II chain		equivalent	protein	sheep MHC class II locus	

--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -3,6 +3,8 @@ ID	A rdfs:label	A IAO:0000111	A OBI:9991118	CLASS_TYPE	C %	C %	A IAO:0000115	A I
 ECO:0000000	evidence	evidence		subclass	information content entity					http://purl.obolibrary.org/obo/eco.owl	
 GO:0042611	MHC protein complex	MHC protein complex	MHC molecule	equivalent	protein-containing complex	('has part' some (protein and ('gene product of' some 'MHC locus')))	A transmembrane protein complex composed of an MHC alpha chain and, in most cases, either an MHC class II beta chain or an invariant beta2-microglobin chain, and with or without a bound peptide, lipid, or polysaccharide antigen.	GO		http://purl.obolibrary.org/obo/go.owl	
 NCBITaxon:7959	grass carp	Ctenopharyngodon idella		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ctid
+NCBITaxon:8022	rainbow trout	Oncorhynchus mykiss		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Onmy
+NCBITaxon:8030	atlantic salmon	Salmo salar		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Sasa
 NCBITaxon:8355	clawed frog	Xenopus laevis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Xela
 NCBITaxon:8839	duck	Anas platyrhynchos		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Anpl
 NCBITaxon:9031	chicken	Gallus gallus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Gaga
@@ -21,10 +23,12 @@ NCBITaxon:9685	cat	Felis catus		subclass	organism					http://purl.obolibrary.org
 NCBITaxon:9796	horse	Equus caballus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	ELA
 NCBITaxon:9823	pig	Sus scrofa		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	SLA
 NCBITaxon:9913	cattle	Bos taurus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	BoLA
-NCBITaxon:9940	sheep	Ovis aries		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ovar
+NCBITaxon:9925	goat	Capra hircus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Cahi
+NCBITaxon:9940	domestic sheep	Ovis aries		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ovar
 NCBITaxon:9986	rabbit	Oryctolagus cuniculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	RLA
 NCBITaxon:10090	mouse	Mus musculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	H2
 NCBITaxon:10116	rat	Rattus norvegicus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	RT1
+NCBITaxon:37174	bighorn sheep	Ovis canadensis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ovca
 PR:000000001	protein	protein		subclass	material entity					http://purl.obolibrary.org/obo/pr.owl	
 PR:000004580	Beta-2-microglobulin	Beta-2-microglobulin		equivalent	protein	('gene product of' some 'Beta-2-microglobulin locus')	A protein that is a translation product of the human B2M gene or a 1:1 ortholog thereof.			http://purl.obolibrary.org/obo/pr.owl	
 REO:0000079	genetic locus	genetic locus		subclass	genetic entity		a nucleic acid sequence region that is part of a genome and represents a specified location or region on a chromosome or other genomic element.			http://purl.obolibrary.org/obo/reo.owl	

--- a/ontology/genetic-locus.tsv
+++ b/ontology/genetic-locus.tsv
@@ -136,6 +136,8 @@ crab-eating macaque MHC class I locus		subclass	MHC class I locus	crab-eating ma
 crab-eating macaque MHC class II locus		subclass	MHC class II locus	crab-eating macaque
 dog MHC class I locus		subclass	MHC class I locus	dog
 dog MHC class II locus		subclass	MHC class II locus	dog
+domestic sheep MHC class I locus		subclass	MHC class I locus	domestic sheep
+domestic sheep MHC class II locus		subclass	MHC class II locus	domestic sheep
 duck MHC class I locus		subclass	MHC class I locus	duck
 giant panda MHC class I locus		subclass	MHC class I locus	giant panda
 giant panda MHC class II locus		subclass	MHC class II locus	giant panda
@@ -166,5 +168,3 @@ rat non-classical MHC locus		subclass	non-classical MHC locus	rat
 rhesus macaque MHC class I locus		subclass	MHC class I locus	rhesus macaque
 rhesus macaque MHC class II locus		subclass	MHC class II locus	rhesus macaque
 rhesus macaque non-classical MHC locus		subclass	non-classical MHC locus	rhesus macaque
-sheep MHC class I locus		subclass	MHC class I locus	sheep
-sheep MHC class II locus		subclass	MHC class II locus	sheep

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -24513,8 +24513,8 @@ Patr-DRB7*01:01 protein complex	Patr-DRB7*01:01		partial molecule	equivalent	MHC
 Patr-DRB*W008:01 protein complex	Patr-DRB*W008:01		partial molecule	equivalent	MHC class II protein complex	chimpanzee	Patr-DRA chain	Patr-DRB*W008:01 chain		
 Ptal-N protein complex	Ptal-N		locus	equivalent	MHC class I protein complex	black flying fox	Ptal-N chain	Beta-2-microglobulin		
 Ptal-N*01:01 protein complex	Ptal-N*01:01		complete molecule	equivalent	MHC class I protein complex	black flying fox	Ptal-N*01:01 chain	Beta-2-microglobulin		
-RLA-A protein complex	RLA-A		locus	equivalent	rabbit MHC class I protein complex	rabbit	RLA-A chain	Beta-2-microglobulin		
-RLA-A*01 protein complex	RLA-A*01		complete molecule	equivalent	RLA-A protein complex	rabbit	RLA-A*01 chain	Beta-2-microglobulin		
+RLA-A protein complex	RLA-A		locus	equivalent	MHC class I protein complex	rabbit	RLA-A chain	Beta-2-microglobulin		
+RLA-A*01 protein complex	RLA-A*01		complete molecule	equivalent	MHC class I protein complex	rabbit	RLA-A*01 chain	Beta-2-microglobulin		
 RT1-A1 protein complex	RT1-A1	RT1.A1(N)|RT1A1	locus	equivalent	MHC class I protein complex	rat	RT1-A1 chain	Beta-2-microglobulin		
 RT1-A2 protein complex	RT1-A2	RT1.A2(N)|RT1A2	locus	equivalent	MHC class I protein complex	rat	RT1-A2 chain	Beta-2-microglobulin		
 RT1-A protein complex	RT1-A	RT1A	locus	equivalent	MHC class I protein complex	rat	RT1-A chain	Beta-2-microglobulin		
@@ -24964,6 +24964,10 @@ SLA-DRB5*01:01 protein complex	SLA-DRB5*01:01		partial molecule	equivalent	MHC c
 Saoe-G protein complex	Saoe-G		locus	equivalent	MHC class I protein complex	cotton-top tamarin	Saoe-G chain	Beta-2-microglobulin		
 Xela-UAAg protein complex	Xela-UAAg		locus	equivalent	MHC class I protein complex	clawed frog	Xela-UAAg chain	Beta-2-microglobulin		
 YF1w*7.1 protein complex	YF1w*7.1	YF1*7.1	complete molecule	equivalent	non-classical MHC protein complex	chicken	YF1w*7.1 chain		YF1 haplotype	
+atlantic salmon MHC class I protein complex	atlantic salmon		class	equivalent	MHC class I protein complex	atlantic salmon				
+atlantic salmon MHC class II protein complex	atlantic salmon		class	equivalent	MHC class II protein complex	atlantic salmon				
+bighorn sheep MHC class I protein complex	bighorn sheep		class	equivalent	MHC class I protein complex	bighorn sheep				
+bighorn sheep MHC class II protein complex	bighorn sheep		class	equivalent	MHC class II protein complex	bighorn sheep				
 black flying fox MHC class I protein complex	black flying fox		class	equivalent	MHC class I protein complex	black flying fox				
 bonobo MHC class I protein complex	bonobo		class	equivalent	MHC class I protein complex	bonobo				
 bonobo MHC class I protein complex	bonobo		class	equivalent	MHC class I protein complex	bonobo				
@@ -24996,9 +25000,13 @@ crab-eating macaque MHC class I protein complex	crab-eating macaque		class	equiv
 crab-eating macaque MHC class II protein complex	crab-eating macaque		class	equivalent	MHC class II protein complex	crab-eating macaque				
 dog MHC class I protein complex	dog		class	equivalent	MHC class I protein complex	dog				
 dog MHC class II protein complex	dog		class	equivalent	MHC class II protein complex	dog				
+domestic sheep MHC class I protein complex	domestic sheep		class	equivalent	MHC class I protein complex	domestic sheep				
+domestic sheep MHC class II protein complex	domestic sheep		class	equivalent	MHC class II protein complex	domestic sheep				
 duck MHC class I protein complex	duck		class	equivalent	MHC class I protein complex	duck				
 giant panda MHC class I protein complex	giant panda		class	equivalent	MHC class I protein complex	giant panda				
 giant panda MHC class II protein complex	giant panda		class	equivalent	MHC class II protein complex	giant panda				
+goat MHC class I protein complex	goat		class	equivalent	MHC class I protein complex	goat				
+goat MHC class II protein complex	goat		class	equivalent	MHC class II protein complex	goat				
 gorilla MHC class I protein complex	gorilla		class	equivalent	MHC class I protein complex	gorilla				
 gorilla MHC class I protein complex	gorilla		class	equivalent	MHC class I protein complex	gorilla				
 gorilla MHC class II protein complex	gorilla		class	equivalent	MHC class II protein complex	gorilla				
@@ -25028,6 +25036,8 @@ pig MHC class I protein complex	pig		class	equivalent	MHC class I protein comple
 pig MHC class II protein complex	pig		class	equivalent	MHC class II protein complex	pig				
 rabbit MHC class I protein complex	rabbit		class	equivalent	MHC class I protein complex	rabbit				
 rabbit MHC class II protein complex	rabbit		class	equivalent	MHC class II protein complex	rabbit				
+rainbow trout MHC class I protein complex	rainbow trout		class	equivalent	MHC class I protein complex	rainbow trout				
+rainbow trout MHC class II protein complex	rainbow trout		class	equivalent	MHC class II protein complex	rainbow trout				
 rat CD1d protein complex	rat CD1d	rCD1d	complete molecule	equivalent	non-classical MHC protein complex	rat	rat CD1d chain	Beta-2-microglobulin		
 rat MHC class I protein complex	rat		class	equivalent	MHC class I protein complex	rat				
 rat MHC class II protein complex	rat		class	equivalent	MHC class II protein complex	rat				
@@ -25040,5 +25050,3 @@ rhesus macaque MHC class II protein complex	rhesus macaque		class	equivalent	MHC
 rhesus macaque MHC class II protein complex	rhesus macaque		class	equivalent	MHC class II protein complex	rhesus macaque				
 rhesus macaque MR1 protein complex	rhesus macaque MR1		complete molecule	equivalent	non-classical MHC protein complex	rhesus macaque	rhesus macaque MR1 chain	Beta-2-microglobulin		
 rhesus macaque non-classical MHC protein complex	rhesus macaque		class	equivalent	non-classical MHC protein complex	rhesus macaque				
-sheep MHC class I protein complex	sheep		class	equivalent	MHC class I protein complex	sheep				
-sheep MHC class II protein complex	sheep		class	equivalent	MHC class II protein complex	sheep				


### PR DESCRIPTION
Updates:
- New species with MHC class I & class II protein complexes:
  - rainbow trout
  - atlantic salmon
  - bighorn sheep
  - goat
- Renamed "sheep" to "domestic sheep" to prevent confusion with "bighorn sheep"
- Added expression evidence to chains:
  - HLA-B*35:460Q
  - HLA-C*04:61N
  - HLA-DQA1*01:07Q
- Moved "RLA-A protein complex" and "RLA-A*01 protein complex" under "MHC class I protein complex" to match existing pattern for other terms like these