### PR TITLE
2021-06-23 update

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -20336,3 +20336,6 @@ BoLA-5*072:01 protein complex	20428	5
 BoLA-NC1*012:01 protein complex	20429	NC1		
 BoLA-NC2*001:01 protein complex	20430	NC2		
 HLA-DPA1*02:02/DPB1*02:01 protein complex	20431	DP		
+HLA-DQA1*02:01/DQB1*06:02 protein complex	20432	DQ		
+chicken MHC protein complex with B2 haplotype	20433			
+chicken MHC class II protein complex with BF2 haplotype	20434			

--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -20337,5 +20337,5 @@ BoLA-NC1*012:01 protein complex	20429	NC1
 BoLA-NC2*001:01 protein complex	20430	NC2		
 HLA-DPA1*02:02/DPB1*02:01 protein complex	20431	DP		
 HLA-DQA1*02:01/DQB1*06:02 protein complex	20432	DQ		
-chicken MHC protein complex with B2 haplotype	20433			
+chicken MHC class II protein complex with B2 haplotype	20433			
 chicken MHC class II protein complex with BF2 haplotype	20434			

--- a/index.tsv
+++ b/index.tsv
@@ -45954,3 +45954,4 @@ MRO:0045952	bighorn sheep MHC class II protein complex	owl:Class
 MRO:0045953	goat MHC class II protein complex	owl:Class	
 MRO:0045954	BF2 haplotype	owl:Class	
 MRO:0045955	chicken MHC class II protein complex with BF2 haplotype	owl:Class	
+MRO:0045956	chicken MHC class II protein complex with B2 haplotype	owl:Class	

--- a/index.tsv
+++ b/index.tsv
@@ -45952,6 +45952,5 @@ MRO:0045950	rainbow trout MHC class II protein complex	owl:Class
 MRO:0045951	atlantic salmon MHC class II protein complex	owl:Class	
 MRO:0045952	bighorn sheep MHC class II protein complex	owl:Class	
 MRO:0045953	goat MHC class II protein complex	owl:Class	
-MRO:0045954	chicken MHC protein complex with B2 haplotype	owl:Class	
+MRO:0045954	BF2 haplotype	owl:Class	
 MRO:0045955	chicken MHC class II protein complex with BF2 haplotype	owl:Class	
-MRO:0045956	BF2 haplotype	owl:Class	

--- a/index.tsv
+++ b/index.tsv
@@ -45952,3 +45952,6 @@ MRO:0045950	rainbow trout MHC class II protein complex	owl:Class
 MRO:0045951	atlantic salmon MHC class II protein complex	owl:Class	
 MRO:0045952	bighorn sheep MHC class II protein complex	owl:Class	
 MRO:0045953	goat MHC class II protein complex	owl:Class	
+MRO:0045954	chicken MHC protein complex with B2 haplotype	owl:Class	
+MRO:0045955	chicken MHC class II protein complex with BF2 haplotype	owl:Class	
+MRO:0045956	BF2 haplotype	owl:Class	

--- a/ontology/haplotype-molecule.tsv
+++ b/ontology/haplotype-molecule.tsv
@@ -9,8 +9,10 @@ chicken MHC class I protein complex with B12 haplotype	B12 class I		haplotype	eq
 chicken MHC class I protein complex with B13 haplotype	B13 class I		haplotype	equivalent	MHC class I protein complex	chicken	B13 haplotype
 chicken MHC class I protein complex with B15 haplotype	B15 class I		haplotype	equivalent	MHC class I protein complex	chicken	B15 haplotype
 chicken MHC class I protein complex with B19 haplotype	B19 class I		haplotype	equivalent	MHC class I protein complex	chicken	B19 haplotype
+chicken MHC class II protein complex with BF2 haplotype	BF2 class II		haplotype	equivalent	MHC class II protein complex	chicken	BF2 haplotype
 chicken MHC class II protein complex with BF19 haplotype	BF19 class II		haplotype	equivalent	MHC class II protein complex	chicken	BF19 haplotype
 chicken MHC class II protein complex with BF21 haplotype	BF21 class II		haplotype	equivalent	MHC class II protein complex	chicken	BF21 haplotype
+chicken MHC protein complex with B2 haplotype	B2		haplotype	equivalent	MHC protein complex	chicken	B2 haplotype
 chicken MHC protein complex with B2 haplotype	B2		haplotype	equivalent	MHC protein complex	chicken	B2 haplotype
 chicken MHC protein complex with B4 haplotype	B4		haplotype	equivalent	MHC protein complex	chicken	B4 haplotype
 chicken MHC protein complex with B12 haplotype	B12		haplotype	equivalent	MHC protein complex	chicken	B12 haplotype

--- a/ontology/haplotype-molecule.tsv
+++ b/ontology/haplotype-molecule.tsv
@@ -13,7 +13,6 @@ chicken MHC class II protein complex with BF2 haplotype	BF2 class II		haplotype	
 chicken MHC class II protein complex with BF19 haplotype	BF19 class II		haplotype	equivalent	MHC class II protein complex	chicken	BF19 haplotype
 chicken MHC class II protein complex with BF21 haplotype	BF21 class II		haplotype	equivalent	MHC class II protein complex	chicken	BF21 haplotype
 chicken MHC protein complex with B2 haplotype	B2		haplotype	equivalent	MHC protein complex	chicken	B2 haplotype
-chicken MHC protein complex with B2 haplotype	B2		haplotype	equivalent	MHC protein complex	chicken	B2 haplotype
 chicken MHC protein complex with B4 haplotype	B4		haplotype	equivalent	MHC protein complex	chicken	B4 haplotype
 chicken MHC protein complex with B12 haplotype	B12		haplotype	equivalent	MHC protein complex	chicken	B12 haplotype
 chicken MHC protein complex with B14 haplotype	B14		haplotype	equivalent	MHC protein complex	chicken	B14 haplotype

--- a/ontology/haplotype-molecule.tsv
+++ b/ontology/haplotype-molecule.tsv
@@ -9,6 +9,7 @@ chicken MHC class I protein complex with B12 haplotype	B12 class I		haplotype	eq
 chicken MHC class I protein complex with B13 haplotype	B13 class I		haplotype	equivalent	MHC class I protein complex	chicken	B13 haplotype
 chicken MHC class I protein complex with B15 haplotype	B15 class I		haplotype	equivalent	MHC class I protein complex	chicken	B15 haplotype
 chicken MHC class I protein complex with B19 haplotype	B19 class I		haplotype	equivalent	MHC class I protein complex	chicken	B19 haplotype
+chicken MHC class II protein complex with B2 haplotype	B2 class II		haplotype	equivalent	MHC class II protein complex	chicken	B2 haplotype
 chicken MHC class II protein complex with BF2 haplotype	BF2 class II		haplotype	equivalent	MHC class II protein complex	chicken	BF2 haplotype
 chicken MHC class II protein complex with BF19 haplotype	BF19 class II		haplotype	equivalent	MHC class II protein complex	chicken	BF19 haplotype
 chicken MHC class II protein complex with BF21 haplotype	BF21 class II		haplotype	equivalent	MHC class II protein complex	chicken	BF21 haplotype

--- a/ontology/haplotype.tsv
+++ b/ontology/haplotype.tsv
@@ -16,6 +16,7 @@ B14 haplotype		subclass	chicken haplotype
 B15 haplotype		subclass	chicken haplotype	
 B19 haplotype		subclass	chicken haplotype	
 B21 haplotype		subclass	chicken haplotype	
+BF2 haplotype		subclass	chicken haplotype	
 BF19 haplotype		subclass	chicken haplotype	
 BF21 haplotype		subclass	chicken haplotype	
 DH7A haplotype		subclass	cattle haplotype	


### PR DESCRIPTION
Three new terms:

ID | Label
--- | ---
MRO:0045954 | BF2 haplotype
MRO:0045955 | chicken MHC class II protein complex with BF2 haplotype
MRO:0045956 | chicken MHC class II protein complex with B2 haplotype

And "HLA-DQA1\*02:01/DQB1\*06:02 protein complex" added to the IEDB sheet.