### PR TITLE
Add custom export for molecule table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,9 +345,6 @@ build/mhc_allele_restriction.csv: build/.mro-tdb src/mhc_allele_restriction.rq |
 build/mhc_allele_restriction.tsv: src/clean.py build/mhc_allele_restriction.csv ontology/external.tsv | iedb
 	python3 $^ > $@
 
-build/molecule-terms.txt: ontology/molecule.tsv
-	cut -f1 $< | tail -n +3 > $@
-
 build/molecule_export.tsv: src/scripts/export_molecule_2.py index.tsv ontology/external.tsv ontology/molecule.tsv
 	python3 $^ $@
 

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ build/mhc_allele_restriction.csv: build/.mro-tdb src/mhc_allele_restriction.rq |
 build/mhc_allele_restriction.tsv: src/clean.py build/mhc_allele_restriction.csv ontology/external.tsv | iedb
 	python3 $^ > $@
 
-build/molecule_export.tsv: src/scripts/export_molecule_2.py index.tsv ontology/external.tsv ontology/molecule.tsv
+build/molecule_export.tsv: src/scripts/export_molecule.py index.tsv ontology/external.tsv ontology/molecule.tsv
 	python3 $^ $@
 
 build/ALLELE_FINDER_NAMES.csv: build/.mro-tdb src/names.rq | build/robot.jar iedb

--- a/src/scripts/export_molecule.py
+++ b/src/scripts/export_molecule.py
@@ -1,0 +1,55 @@
+import csv
+import logging
+
+from argparse import ArgumentParser, FileType
+from collections import defaultdict
+
+
+def main():
+	parser = ArgumentParser()
+	parser.add_argument("index", type=FileType("r"))
+	parser.add_argument("external", type=FileType("r"))
+	parser.add_argument("molecule", type=FileType("r"))
+	parser.add_argument("output", type=FileType("w"))
+	args = parser.parse_args()
+
+	label_to_id = {}
+	reader = csv.DictReader(args.index, delimiter="\t")
+	next(reader)
+	for row in reader:
+		label_to_id[row["Label"]] = row["ID"]
+
+	reader = csv.DictReader(args.external, delimiter="\t")
+	next(reader)
+	for row in reader:
+		label_to_id[row["Label"]] = row["ID"]
+
+	output = []
+	reader = csv.DictReader(args.molecule, delimiter="\t")
+	next(reader)
+	for row in reader:
+		term_label = row["Label"]
+		term_id = label_to_id.get(term_label)
+		if not term_id:
+			logging.error(f"Unable to find ID for '{term_label}'")
+			continue
+		parent_label = row["Parent"]
+		parent_id = label_to_id.get(parent_label)
+		if not parent_id:
+			logging.error(f"Unable to find ID for parent term '{parent_label}'")
+		taxon_label = row["In Taxon"]
+		taxon_id = None
+		if taxon_label:
+			taxon_id = label_to_id.get(taxon_label)
+			if not taxon_id:
+				logging.error(f"Unable to find ID for taxon term '{taxon_label}'")
+		output.append({"MRO ID": term_id, "Label": term_label, "IEDB Label": row["IEDB Label"], "Synonyms": row["Synonyms"], "Parent": parent_id, "In Taxon": taxon_label, "In Taxon ID": taxon_id})
+
+	writer = csv.DictWriter(args.output, fieldnames=["MRO ID", "Label", "IEDB Label", "Synonyms", "Parent", "In Taxon", "In Taxon ID"], delimiter="\t", lineterminator="\n")
+	writer.writeheader()
+	writer.writerows(output)
+
+
+if __name__ == '__main__':
+	main()
+

--- a/src/scripts/export_molecule.py
+++ b/src/scripts/export_molecule.py
@@ -49,7 +49,8 @@ def main():
                 "Label": term_label,
                 "IEDB Label": row["IEDB Label"],
                 "Synonyms": row["Synonyms"],
-                "Parent": parent_id,
+                "Parent": parent_label,
+                "Parent ID": parent_id,
                 "In Taxon": taxon_label,
                 "In Taxon ID": taxon_id,
             }
@@ -63,6 +64,7 @@ def main():
             "IEDB Label",
             "Synonyms",
             "Parent",
+            "Parent ID",
             "In Taxon",
             "In Taxon ID",
         ],

--- a/src/scripts/export_molecule.py
+++ b/src/scripts/export_molecule.py
@@ -6,50 +6,72 @@ from collections import defaultdict
 
 
 def main():
-	parser = ArgumentParser()
-	parser.add_argument("index", type=FileType("r"))
-	parser.add_argument("external", type=FileType("r"))
-	parser.add_argument("molecule", type=FileType("r"))
-	parser.add_argument("output", type=FileType("w"))
-	args = parser.parse_args()
+    parser = ArgumentParser()
+    parser.add_argument("index", type=FileType("r"))
+    parser.add_argument("external", type=FileType("r"))
+    parser.add_argument("molecule", type=FileType("r"))
+    parser.add_argument("output", type=FileType("w"))
+    args = parser.parse_args()
 
-	label_to_id = {}
-	reader = csv.DictReader(args.index, delimiter="\t")
-	next(reader)
-	for row in reader:
-		label_to_id[row["Label"]] = row["ID"]
+    label_to_id = {}
+    reader = csv.DictReader(args.index, delimiter="\t")
+    next(reader)
+    for row in reader:
+        label_to_id[row["Label"]] = row["ID"]
 
-	reader = csv.DictReader(args.external, delimiter="\t")
-	next(reader)
-	for row in reader:
-		label_to_id[row["Label"]] = row["ID"]
+    reader = csv.DictReader(args.external, delimiter="\t")
+    next(reader)
+    for row in reader:
+        label_to_id[row["Label"]] = row["ID"]
 
-	output = []
-	reader = csv.DictReader(args.molecule, delimiter="\t")
-	next(reader)
-	for row in reader:
-		term_label = row["Label"]
-		term_id = label_to_id.get(term_label)
-		if not term_id:
-			logging.error(f"Unable to find ID for '{term_label}'")
-			continue
-		parent_label = row["Parent"]
-		parent_id = label_to_id.get(parent_label)
-		if not parent_id:
-			logging.error(f"Unable to find ID for parent term '{parent_label}'")
-		taxon_label = row["In Taxon"]
-		taxon_id = None
-		if taxon_label:
-			taxon_id = label_to_id.get(taxon_label)
-			if not taxon_id:
-				logging.error(f"Unable to find ID for taxon term '{taxon_label}'")
-		output.append({"MRO ID": term_id, "Label": term_label, "IEDB Label": row["IEDB Label"], "Synonyms": row["Synonyms"], "Parent": parent_id, "In Taxon": taxon_label, "In Taxon ID": taxon_id})
+    output = []
+    reader = csv.DictReader(args.molecule, delimiter="\t")
+    next(reader)
+    for row in reader:
+        term_label = row["Label"]
+        term_id = label_to_id.get(term_label)
+        if not term_id:
+            logging.error(f"Unable to find ID for '{term_label}'")
+            continue
+        parent_label = row["Parent"]
+        parent_id = label_to_id.get(parent_label)
+        if not parent_id:
+            logging.error(f"Unable to find ID for parent term '{parent_label}'")
+        taxon_label = row["In Taxon"]
+        taxon_id = None
+        if taxon_label:
+            taxon_id = label_to_id.get(taxon_label)
+            if not taxon_id:
+                logging.error(f"Unable to find ID for taxon term '{taxon_label}'")
+        output.append(
+            {
+                "MRO ID": term_id,
+                "Label": term_label,
+                "IEDB Label": row["IEDB Label"],
+                "Synonyms": row["Synonyms"],
+                "Parent": parent_id,
+                "In Taxon": taxon_label,
+                "In Taxon ID": taxon_id,
+            }
+        )
 
-	writer = csv.DictWriter(args.output, fieldnames=["MRO ID", "Label", "IEDB Label", "Synonyms", "Parent", "In Taxon", "In Taxon ID"], delimiter="\t", lineterminator="\n")
-	writer.writeheader()
-	writer.writerows(output)
+    writer = csv.DictWriter(
+        args.output,
+        fieldnames=[
+            "MRO ID",
+            "Label",
+            "IEDB Label",
+            "Synonyms",
+            "Parent",
+            "In Taxon",
+            "In Taxon ID",
+        ],
+        delimiter="\t",
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    writer.writerows(output)
 
 
-if __name__ == '__main__':
-	main()
-
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This new `molecule_export.tsv` will be packaged in the zip we include with each release. It contains the following:

* MRO ID
* Label
* IEDB Label
* Synonyms (separated by pipe)
* Parent
* In Taxon
* In Taxon ID

I was originally going to use `gizmos.export` for this, but with the "In Taxon" restriction, this took almost 10 minutes, so it just seemed better to use the existing TSVs - which is pretty much instant. That said, I kept the indexes because we'll probably need them anyway.

Resolves #99