### PR TITLE
2021-07-06 Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,17 +158,22 @@ build/mro.html: mro.owl | build/robot.jar
 
 ### Ontology Source Tables
 
-build/%.tsv: ontology/%.tsv | build
+# Replace labels for any term with single quotes used in a C ROBOT template string
+build/%-fixed.tsv: src/scripts/replace_labels.py ontology/%.tsv | build
+	python3 $^ $@
+
+# Some templates don't need automatic synonyms, just copy these directly
+build/%.tsv: build/%-fixed.tsv | build
 	cp $< $@
 
-# Generate automatic synonyms
-build/molecule.tsv: src/scripts/synonyms.py ontology/molecule.tsv | build
+# Generate automatic synonyms for these tables
+build/molecule.tsv: src/scripts/synonyms.py build/molecule-fixed.tsv | build
 	python3 $^ > $@
-build/haplotype-molecule.tsv: src/scripts/synonyms.py ontology/haplotype-molecule.tsv | build
+build/haplotype-molecule.tsv: src/scripts/synonyms.py build/haplotype-molecule-fixed.tsv | build
 	python3 $^ > $@
-build/serotype-molecule.tsv: src/scripts/synonyms.py ontology/serotype-molecule.tsv | build
+build/serotype-molecule.tsv: src/scripts/synonyms.py build/serotype-molecule-fixed.tsv | build
 	python3 $^ > $@
-build/mutant-molecule.tsv: src/scripts/synonyms.py ontology/mutant-molecule.tsv | build
+build/mutant-molecule.tsv: src/scripts/synonyms.py build/mutant-molecule-fixed.tsv | build
 	python3 $^ > $@
 
 # Represent tables in Excel

--- a/Makefile
+++ b/Makefile
@@ -108,12 +108,12 @@ destroy: | .cogs
 
 # Validate the contents of the templates
 .PRECIOUS: build/validation_errors.tsv
-build/validation_errors.tsv: src/scripts/validation/validate_templates.py index.tsv iedb/iedb.tsv $(build_files)
-	python3 $< index.tsv iedb/iedb.tsv build $@ -a
+build/validation_errors.tsv: src/scripts/validation/validate_templates.py index.tsv iedb/iedb.tsv $(source_files)
+	python3 $< index.tsv iedb/iedb.tsv ontology $@ -a
 
 .PRECIOUS: build/validation_errors_strict.tsv
-build/validation_errors_strict.tsv: src/scripts/validation/validate_templates.py index.tsv iedb/iedb.tsv $(build_files)
-	python3 $< index.tsv iedb/iedb.tsv build $@
+build/validation_errors_strict.tsv: src/scripts/validation/validate_templates.py index.tsv iedb/iedb.tsv $(source_files)
+	python3 $< index.tsv iedb/iedb.tsv ontology $@
 
 apply_%: build/validation_%.tsv | .cogs
 	cogs clear all

--- a/index.tsv
+++ b/index.tsv
@@ -45955,3 +45955,297 @@ MRO:0045953	goat MHC class II protein complex	owl:Class
 MRO:0045954	BF2 haplotype	owl:Class	
 MRO:0045955	chicken MHC class II protein complex with BF2 haplotype	owl:Class	
 MRO:0045956	chicken MHC class II protein complex with B2 haplotype	owl:Class	
+MRO:0045957	Guatemalan black howler MHC class I locus	owl:Class	
+MRO:0045958	Guatemalan black howler MHC class II locus	owl:Class	
+MRO:0045959	Azara's night monkey MHC class I locus	owl:Class	
+MRO:0045960	Azara's night monkey MHC class II locus	owl:Class	
+MRO:0045961	gray-bellied night monkey MHC class I locus	owl:Class	
+MRO:0045962	gray-bellied night monkey MHC class II locus	owl:Class	
+MRO:0045963	Nancy Ma's night monkey MHC class I locus	owl:Class	
+MRO:0045964	Nancy Ma's night monkey MHC class II locus	owl:Class	
+MRO:0045965	black-headed night monkey MHC class I locus	owl:Class	
+MRO:0045966	black-headed night monkey MHC class II locus	owl:Class	
+MRO:0045967	three-striped night monkey MHC class I locus	owl:Class	
+MRO:0045968	three-striped night monkey MHC class II locus	owl:Class	
+MRO:0045969	Spix's night monkey MHC class I locus	owl:Class	
+MRO:0045970	Spix's night monkey MHC class II locus	owl:Class	
+MRO:0045971	white-fronted spider monkey MHC class I locus	owl:Class	
+MRO:0045972	white-fronted spider monkey MHC class II locus	owl:Class	
+MRO:0045973	black-headed spider monkey MHC class I locus	owl:Class	
+MRO:0045974	black-headed spider monkey MHC class II locus	owl:Class	
+MRO:0045975	red-bellied titi MHC class I locus	owl:Class	
+MRO:0045976	red-bellied titi MHC class II locus	owl:Class	
+MRO:0045977	pygmy marmoset MHC class I locus	owl:Class	
+MRO:0045978	pygmy marmoset MHC class II locus	owl:Class	
+MRO:0045979	tufted capuchin MHC class I locus	owl:Class	
+MRO:0045980	tufted capuchin MHC class II locus	owl:Class	
+MRO:0045981	sooty mangabey MHC class I locus	owl:Class	
+MRO:0045982	sooty mangabey MHC class II locus	owl:Class	
+MRO:0045983	blue monkey MHC class I locus	owl:Class	
+MRO:0045984	blue monkey MHC class II locus	owl:Class	
+MRO:0045985	De Brazza's monkey MHC class I locus	owl:Class	
+MRO:0045986	De Brazza's monkey MHC class II locus	owl:Class	
+MRO:0045987	grivet MHC class I locus	owl:Class	
+MRO:0045988	grivet MHC class II locus	owl:Class	
+MRO:0045989	vervet monkey MHC class I locus	owl:Class	
+MRO:0045990	vervet monkey MHC class II locus	owl:Class	
+MRO:0045991	green monkey MHC class I locus	owl:Class	
+MRO:0045992	green monkey MHC class II locus	owl:Class	
+MRO:0045993	mantled guereza MHC class I locus	owl:Class	
+MRO:0045994	mantled guereza MHC class II locus	owl:Class	
+MRO:0045995	eastern gorilla MHC class I locus	owl:Class	
+MRO:0045996	eastern gorilla MHC class II locus	owl:Class	
+MRO:0045997	lar gibbon MHC class I locus	owl:Class	
+MRO:0045998	lar gibbon MHC class II locus	owl:Class	
+MRO:0045999	silvery Javan gibbon MHC class I locus	owl:Class	
+MRO:0046000	silvery Javan gibbon MHC class II locus	owl:Class	
+MRO:0046001	golden lion tamarin MHC class I locus	owl:Class	
+MRO:0046002	golden lion tamarin MHC class II locus	owl:Class	
+MRO:0046003	black crested mangabey MHC class I locus	owl:Class	
+MRO:0046004	black crested mangabey MHC class II locus	owl:Class	
+MRO:0046005	stump-tailed macaque MHC class I locus	owl:Class	
+MRO:0046006	stump-tailed macaque MHC class II locus	owl:Class	
+MRO:0046007	Assam macaque MHC class I locus	owl:Class	
+MRO:0046008	Assam macaque MHC class II locus	owl:Class	
+MRO:0046009	Japanese macaque MHC class I locus	owl:Class	
+MRO:0046010	Japanese macaque MHC class II locus	owl:Class	
+MRO:0046011	drill MHC class I locus	owl:Class	
+MRO:0046012	drill MHC class II locus	owl:Class	
+MRO:0046013	northern pig-tailed macaque MHC class I locus	owl:Class	
+MRO:0046014	northern pig-tailed macaque MHC class II locus	owl:Class	
+MRO:0046015	southern pig-tailed macaque MHC class I locus	owl:Class	
+MRO:0046016	southern pig-tailed macaque MHC class II locus	owl:Class	
+MRO:0046017	lion-tailed macaque MHC class I locus	owl:Class	
+MRO:0046018	lion-tailed macaque MHC class II locus	owl:Class	
+MRO:0046019	mandrill MHC class I locus	owl:Class	
+MRO:0046020	mandrill MHC class II locus	owl:Class	
+MRO:0046021	Milne Edward's macaque MHC class I locus	owl:Class	
+MRO:0046022	Milne Edward's macaque MHC class II locus	owl:Class	
+MRO:0046023	olive baboon MHC class I locus	owl:Class	
+MRO:0046024	olive baboon MHC class II locus	owl:Class	
+MRO:0046025	yellow baboon MHC class I locus	owl:Class	
+MRO:0046026	yellow baboon MHC class II locus	owl:Class	
+MRO:0046027	hamadryas baboon MHC class I locus	owl:Class	
+MRO:0046028	hamadryas baboon MHC class II locus	owl:Class	
+MRO:0046029	Guinea baboon MHC class I locus	owl:Class	
+MRO:0046030	Guinea baboon MHC class II locus	owl:Class	
+MRO:0046031	chacma Baboon MHC class I locus	owl:Class	
+MRO:0046032	chacma Baboon MHC class II locus	owl:Class	
+MRO:0046033	white-faced saki MHC class I locus	owl:Class	
+MRO:0046034	white-faced saki MHC class II locus	owl:Class	
+MRO:0046035	Sumatran orangutan MHC class I locus	owl:Class	
+MRO:0046036	Sumatran orangutan MHC class II locus	owl:Class	
+MRO:0046037	Bornean orangutan MHC class I locus	owl:Class	
+MRO:0046038	Bornean orangutan MHC class II locus	owl:Class	
+MRO:0046039	golden snub-nosed monkey MHC class I locus	owl:Class	
+MRO:0046040	golden snub-nosed monkey MHC class II locus	owl:Class	
+MRO:0046041	brown-mantled tamarin MHC class I locus	owl:Class	
+MRO:0046042	brown-mantled tamarin MHC class II locus	owl:Class	
+MRO:0046043	Geoffroy's tamarin MHC class I locus	owl:Class	
+MRO:0046044	Geoffroy's tamarin MHC class II locus	owl:Class	
+MRO:0046045	white-lipped tamarin MHC class I locus	owl:Class	
+MRO:0046046	white-lipped tamarin MHC class II locus	owl:Class	
+MRO:0046047	moustached tamarin MHC class I locus	owl:Class	
+MRO:0046048	moustached tamarin MHC class II locus	owl:Class	
+MRO:0046049	common squirrel monkey MHC class I locus	owl:Class	
+MRO:0046050	common squirrel monkey MHC class II locus	owl:Class	
+MRO:0046051	northern plains gray langur MHC class I locus	owl:Class	
+MRO:0046052	northern plains gray langur MHC class II locus	owl:Class	
+MRO:0046053	gelada MHC class I locus	owl:Class	
+MRO:0046054	gelada MHC class II locus	owl:Class	
+MRO:0046055	Guatemalan black howler MHC class I chain	owl:Class	
+MRO:0046056	Guatemalan black howler MHC class II chain	owl:Class	
+MRO:0046057	Azara's night monkey MHC class I chain	owl:Class	
+MRO:0046058	Azara's night monkey MHC class II chain	owl:Class	
+MRO:0046059	gray-bellied night monkey MHC class I chain	owl:Class	
+MRO:0046060	gray-bellied night monkey MHC class II chain	owl:Class	
+MRO:0046061	Nancy Ma's night monkey MHC class I chain	owl:Class	
+MRO:0046062	Nancy Ma's night monkey MHC class II chain	owl:Class	
+MRO:0046063	black-headed night monkey MHC class I chain	owl:Class	
+MRO:0046064	black-headed night monkey MHC class II chain	owl:Class	
+MRO:0046065	three-striped night monkey MHC class I chain	owl:Class	
+MRO:0046066	three-striped night monkey MHC class II chain	owl:Class	
+MRO:0046067	Spix's night monkey MHC class I chain	owl:Class	
+MRO:0046068	Spix's night monkey MHC class II chain	owl:Class	
+MRO:0046069	white-fronted spider monkey MHC class I chain	owl:Class	
+MRO:0046070	white-fronted spider monkey MHC class II chain	owl:Class	
+MRO:0046071	black-headed spider monkey MHC class I chain	owl:Class	
+MRO:0046072	black-headed spider monkey MHC class II chain	owl:Class	
+MRO:0046073	red-bellied titi MHC class I chain	owl:Class	
+MRO:0046074	red-bellied titi MHC class II chain	owl:Class	
+MRO:0046075	pygmy marmoset MHC class I chain	owl:Class	
+MRO:0046076	pygmy marmoset MHC class II chain	owl:Class	
+MRO:0046077	tufted capuchin MHC class I chain	owl:Class	
+MRO:0046078	tufted capuchin MHC class II chain	owl:Class	
+MRO:0046079	sooty mangabey MHC class I chain	owl:Class	
+MRO:0046080	sooty mangabey MHC class II chain	owl:Class	
+MRO:0046081	blue monkey MHC class I chain	owl:Class	
+MRO:0046082	blue monkey MHC class II chain	owl:Class	
+MRO:0046083	De Brazza's monkey MHC class I chain	owl:Class	
+MRO:0046084	De Brazza's monkey MHC class II chain	owl:Class	
+MRO:0046085	grivet MHC class I chain	owl:Class	
+MRO:0046086	grivet MHC class II chain	owl:Class	
+MRO:0046087	vervet monkey MHC class I chain	owl:Class	
+MRO:0046088	vervet monkey MHC class II chain	owl:Class	
+MRO:0046089	green monkey MHC class I chain	owl:Class	
+MRO:0046090	green monkey MHC class II chain	owl:Class	
+MRO:0046091	mantled guereza MHC class I chain	owl:Class	
+MRO:0046092	mantled guereza MHC class II chain	owl:Class	
+MRO:0046093	eastern gorilla MHC class I chain	owl:Class	
+MRO:0046094	eastern gorilla MHC class II chain	owl:Class	
+MRO:0046095	lar gibbon MHC class I chain	owl:Class	
+MRO:0046096	lar gibbon MHC class II chain	owl:Class	
+MRO:0046097	silvery Javan gibbon MHC class I chain	owl:Class	
+MRO:0046098	silvery Javan gibbon MHC class II chain	owl:Class	
+MRO:0046099	golden lion tamarin MHC class I chain	owl:Class	
+MRO:0046100	golden lion tamarin MHC class II chain	owl:Class	
+MRO:0046101	black crested mangabey MHC class I chain	owl:Class	
+MRO:0046102	black crested mangabey MHC class II chain	owl:Class	
+MRO:0046103	stump-tailed macaque MHC class I chain	owl:Class	
+MRO:0046104	stump-tailed macaque MHC class II chain	owl:Class	
+MRO:0046105	Assam macaque MHC class I chain	owl:Class	
+MRO:0046106	Assam macaque MHC class II chain	owl:Class	
+MRO:0046107	Japanese macaque MHC class I chain	owl:Class	
+MRO:0046108	Japanese macaque MHC class II chain	owl:Class	
+MRO:0046109	drill MHC class I chain	owl:Class	
+MRO:0046110	drill MHC class II chain	owl:Class	
+MRO:0046111	northern pig-tailed macaque MHC class I chain	owl:Class	
+MRO:0046112	northern pig-tailed macaque MHC class II chain	owl:Class	
+MRO:0046113	southern pig-tailed macaque MHC class I chain	owl:Class	
+MRO:0046114	southern pig-tailed macaque MHC class II chain	owl:Class	
+MRO:0046115	lion-tailed macaque MHC class I chain	owl:Class	
+MRO:0046116	lion-tailed macaque MHC class II chain	owl:Class	
+MRO:0046117	mandrill MHC class I chain	owl:Class	
+MRO:0046118	mandrill MHC class II chain	owl:Class	
+MRO:0046119	Milne Edward's macaque MHC class I chain	owl:Class	
+MRO:0046120	Milne Edward's macaque MHC class II chain	owl:Class	
+MRO:0046121	olive baboon MHC class I chain	owl:Class	
+MRO:0046122	olive baboon MHC class II chain	owl:Class	
+MRO:0046123	yellow baboon MHC class I chain	owl:Class	
+MRO:0046124	yellow baboon MHC class II chain	owl:Class	
+MRO:0046125	hamadryas baboon MHC class I chain	owl:Class	
+MRO:0046126	hamadryas baboon MHC class II chain	owl:Class	
+MRO:0046127	Guinea baboon MHC class I chain	owl:Class	
+MRO:0046128	Guinea baboon MHC class II chain	owl:Class	
+MRO:0046129	chacma Baboon MHC class I chain	owl:Class	
+MRO:0046130	chacma Baboon MHC class II chain	owl:Class	
+MRO:0046131	white-faced saki MHC class I chain	owl:Class	
+MRO:0046132	white-faced saki MHC class II chain	owl:Class	
+MRO:0046133	Sumatran orangutan MHC class I chain	owl:Class	
+MRO:0046134	Sumatran orangutan MHC class II chain	owl:Class	
+MRO:0046135	Bornean orangutan MHC class I chain	owl:Class	
+MRO:0046136	Bornean orangutan MHC class II chain	owl:Class	
+MRO:0046137	golden snub-nosed monkey MHC class I chain	owl:Class	
+MRO:0046138	golden snub-nosed monkey MHC class II chain	owl:Class	
+MRO:0046139	brown-mantled tamarin MHC class I chain	owl:Class	
+MRO:0046140	brown-mantled tamarin MHC class II chain	owl:Class	
+MRO:0046141	Geoffroy's tamarin MHC class I chain	owl:Class	
+MRO:0046142	Geoffroy's tamarin MHC class II chain	owl:Class	
+MRO:0046143	white-lipped tamarin MHC class I chain	owl:Class	
+MRO:0046144	white-lipped tamarin MHC class II chain	owl:Class	
+MRO:0046145	moustached tamarin MHC class I chain	owl:Class	
+MRO:0046146	moustached tamarin MHC class II chain	owl:Class	
+MRO:0046147	common squirrel monkey MHC class I chain	owl:Class	
+MRO:0046148	common squirrel monkey MHC class II chain	owl:Class	
+MRO:0046149	northern plains gray langur MHC class I chain	owl:Class	
+MRO:0046150	northern plains gray langur MHC class II chain	owl:Class	
+MRO:0046151	gelada MHC class I chain	owl:Class	
+MRO:0046152	gelada MHC class II chain	owl:Class	
+MRO:0046153	Guatemalan black howler MHC class I protein complex	owl:Class	
+MRO:0046154	Guatemalan black howler MHC class II protein complex	owl:Class	
+MRO:0046155	Azara's night monkey MHC class I protein complex	owl:Class	
+MRO:0046156	Azara's night monkey MHC class II protein complex	owl:Class	
+MRO:0046157	gray-bellied night monkey MHC class I protein complex	owl:Class	
+MRO:0046158	gray-bellied night monkey MHC class II protein complex	owl:Class	
+MRO:0046159	Nancy Ma's night monkey MHC class I protein complex	owl:Class	
+MRO:0046160	Nancy Ma's night monkey MHC class II protein complex	owl:Class	
+MRO:0046161	black-headed night monkey MHC class I protein complex	owl:Class	
+MRO:0046162	black-headed night monkey MHC class II protein complex	owl:Class	
+MRO:0046163	three-striped night monkey MHC class I protein complex	owl:Class	
+MRO:0046164	three-striped night monkey MHC class II protein complex	owl:Class	
+MRO:0046165	Spix's night monkey MHC class I protein complex	owl:Class	
+MRO:0046166	Spix's night monkey MHC class II protein complex	owl:Class	
+MRO:0046167	white-fronted spider monkey MHC class I protein complex	owl:Class	
+MRO:0046168	white-fronted spider monkey MHC class II protein complex	owl:Class	
+MRO:0046169	black-headed spider monkey MHC class I protein complex	owl:Class	
+MRO:0046170	black-headed spider monkey MHC class II protein complex	owl:Class	
+MRO:0046171	red-bellied titi MHC class I protein complex	owl:Class	
+MRO:0046172	red-bellied titi MHC class II protein complex	owl:Class	
+MRO:0046173	pygmy marmoset MHC class I protein complex	owl:Class	
+MRO:0046174	pygmy marmoset MHC class II protein complex	owl:Class	
+MRO:0046175	tufted capuchin MHC class I protein complex	owl:Class	
+MRO:0046176	tufted capuchin MHC class II protein complex	owl:Class	
+MRO:0046177	sooty mangabey MHC class I protein complex	owl:Class	
+MRO:0046178	sooty mangabey MHC class II protein complex	owl:Class	
+MRO:0046179	blue monkey MHC class I protein complex	owl:Class	
+MRO:0046180	blue monkey MHC class II protein complex	owl:Class	
+MRO:0046181	De Brazza's monkey MHC class I protein complex	owl:Class	
+MRO:0046182	De Brazza's monkey MHC class II protein complex	owl:Class	
+MRO:0046183	grivet MHC class I protein complex	owl:Class	
+MRO:0046184	grivet MHC class II protein complex	owl:Class	
+MRO:0046185	vervet monkey MHC class I protein complex	owl:Class	
+MRO:0046186	vervet monkey MHC class II protein complex	owl:Class	
+MRO:0046187	green monkey MHC class I protein complex	owl:Class	
+MRO:0046188	green monkey MHC class II protein complex	owl:Class	
+MRO:0046189	mantled guereza MHC class I protein complex	owl:Class	
+MRO:0046190	mantled guereza MHC class II protein complex	owl:Class	
+MRO:0046191	eastern gorilla MHC class I protein complex	owl:Class	
+MRO:0046192	eastern gorilla MHC class II protein complex	owl:Class	
+MRO:0046193	lar gibbon MHC class I protein complex	owl:Class	
+MRO:0046194	lar gibbon MHC class II protein complex	owl:Class	
+MRO:0046195	silvery Javan gibbon MHC class I protein complex	owl:Class	
+MRO:0046196	silvery Javan gibbon MHC class II protein complex	owl:Class	
+MRO:0046197	golden lion tamarin MHC class I protein complex	owl:Class	
+MRO:0046198	golden lion tamarin MHC class II protein complex	owl:Class	
+MRO:0046199	black crested mangabey MHC class I protein complex	owl:Class	
+MRO:0046200	black crested mangabey MHC class II protein complex	owl:Class	
+MRO:0046201	stump-tailed macaque MHC class I protein complex	owl:Class	
+MRO:0046202	stump-tailed macaque MHC class II protein complex	owl:Class	
+MRO:0046203	Assam macaque MHC class I protein complex	owl:Class	
+MRO:0046204	Assam macaque MHC class II protein complex	owl:Class	
+MRO:0046205	Japanese macaque MHC class I protein complex	owl:Class	
+MRO:0046206	Japanese macaque MHC class II protein complex	owl:Class	
+MRO:0046207	drill MHC class I protein complex	owl:Class	
+MRO:0046208	drill MHC class II protein complex	owl:Class	
+MRO:0046209	northern pig-tailed macaque MHC class I protein complex	owl:Class	
+MRO:0046210	northern pig-tailed macaque MHC class II protein complex	owl:Class	
+MRO:0046211	southern pig-tailed macaque MHC class I protein complex	owl:Class	
+MRO:0046212	southern pig-tailed macaque MHC class II protein complex	owl:Class	
+MRO:0046213	lion-tailed macaque MHC class I protein complex	owl:Class	
+MRO:0046214	lion-tailed macaque MHC class II protein complex	owl:Class	
+MRO:0046215	mandrill MHC class I protein complex	owl:Class	
+MRO:0046216	mandrill MHC class II protein complex	owl:Class	
+MRO:0046217	Milne Edward's macaque MHC class I protein complex	owl:Class	
+MRO:0046218	Milne Edward's macaque MHC class II protein complex	owl:Class	
+MRO:0046219	olive baboon MHC class I protein complex	owl:Class	
+MRO:0046220	olive baboon MHC class II protein complex	owl:Class	
+MRO:0046221	yellow baboon MHC class I protein complex	owl:Class	
+MRO:0046222	yellow baboon MHC class II protein complex	owl:Class	
+MRO:0046223	hamadryas baboon MHC class I protein complex	owl:Class	
+MRO:0046224	hamadryas baboon MHC class II protein complex	owl:Class	
+MRO:0046225	Guinea baboon MHC class I protein complex	owl:Class	
+MRO:0046226	Guinea baboon MHC class II protein complex	owl:Class	
+MRO:0046227	chacma Baboon MHC class I protein complex	owl:Class	
+MRO:0046228	chacma Baboon MHC class II protein complex	owl:Class	
+MRO:0046229	white-faced saki MHC class I protein complex	owl:Class	
+MRO:0046230	white-faced saki MHC class II protein complex	owl:Class	
+MRO:0046231	Sumatran orangutan MHC class I protein complex	owl:Class	
+MRO:0046232	Sumatran orangutan MHC class II protein complex	owl:Class	
+MRO:0046233	Bornean orangutan MHC class I protein complex	owl:Class	
+MRO:0046234	Bornean orangutan MHC class II protein complex	owl:Class	
+MRO:0046235	golden snub-nosed monkey MHC class I protein complex	owl:Class	
+MRO:0046236	golden snub-nosed monkey MHC class II protein complex	owl:Class	
+MRO:0046237	brown-mantled tamarin MHC class I protein complex	owl:Class	
+MRO:0046238	brown-mantled tamarin MHC class II protein complex	owl:Class	
+MRO:0046239	Geoffroy's tamarin MHC class I protein complex	owl:Class	
+MRO:0046240	Geoffroy's tamarin MHC class II protein complex	owl:Class	
+MRO:0046241	white-lipped tamarin MHC class I protein complex	owl:Class	
+MRO:0046242	white-lipped tamarin MHC class II protein complex	owl:Class	
+MRO:0046243	moustached tamarin MHC class I protein complex	owl:Class	
+MRO:0046244	moustached tamarin MHC class II protein complex	owl:Class	
+MRO:0046245	common squirrel monkey MHC class I protein complex	owl:Class	
+MRO:0046246	common squirrel monkey MHC class II protein complex	owl:Class	
+MRO:0046247	northern plains gray langur MHC class I protein complex	owl:Class	
+MRO:0046248	northern plains gray langur MHC class II protein complex	owl:Class	
+MRO:0046249	gelada MHC class I protein complex	owl:Class	
+MRO:0046250	gelada MHC class II protein complex	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -4,6 +4,10 @@ Aime-128 chain		equivalent	protein	Aime-128 locus
 Anpl-UAA chain		equivalent	protein	Anpl-UAA locus	
 Anpl-UAA*01 chain		subclass	Anpl-UAA chain		
 Anpl-UAA*SD chain		subclass	Anpl-UAA chain		
+Assam macaque MHC class I chain		equivalent	protein	Assam macaque MHC class I locus	
+Assam macaque MHC class II chain		equivalent	protein	Assam macaque MHC class II locus	
+Azara's night monkey MHC class I chain		equivalent	protein	Azara's night monkey MHC class I locus	
+Azara's night monkey MHC class II chain		equivalent	protein	Azara's night monkey MHC class II locus	
 BoLA-1 chain		equivalent	protein	BoLA-1 locus	
 BoLA-1*007:01 chain		subclass	BoLA-1 chain		
 BoLA-1*009:01 chain		subclass	BoLA-1 chain		
@@ -695,6 +699,8 @@ BoLA-NC4*001:01 chain		subclass	BoLA-NC4 chain
 BoLA-NC4*002:01 chain		subclass	BoLA-NC4 chain		
 BoLA-NC4*002:02 chain		subclass	BoLA-NC4 chain		
 BoLA-NC4*003:01 chain		subclass	BoLA-NC4 chain		
+Bornean orangutan MHC class I chain		equivalent	protein	Bornean orangutan MHC class I locus	
+Bornean orangutan MHC class II chain		equivalent	protein	Bornean orangutan MHC class II locus	
 Caja-E chain		equivalent	protein	Caja-E locus	
 Caja-G chain		equivalent	protein	Caja-G locus	
 Ctid-UAA chain		equivalent	protein	Ctid-UAA locus	
@@ -702,6 +708,8 @@ DLA-88 chain		equivalent	protein	DLA-88 locus
 DLA-88*034:01 chain		subclass	DLA-88 chain		
 DLA-88*501:01 chain		subclass	DLA-88 chain		
 DLA-88*508:01 chain		subclass	DLA-88 chain		
+De Brazza's monkey MHC class I chain		equivalent	protein	De Brazza's monkey MHC class I locus	
+De Brazza's monkey MHC class II chain		equivalent	protein	De Brazza's monkey MHC class II locus	
 ELA-1 chain		equivalent	protein	ELA-1 locus	
 ELA-16 chain		equivalent	protein	ELA-16 locus	
 ELA-N chain		equivalent	protein	ELA-N locus	
@@ -725,8 +733,14 @@ Gaga-BF2*021:01 chain		subclass	Gaga-BF2 chain
 Gaga-BF2*1301 chain		subclass	Gaga-BF2 chain		
 Gaga-BF-B chain		equivalent	protein	Gaga-BF-B locus	
 Gaga-BF-YF chain		equivalent	protein	Gaga-BF-YF locus	
+Geoffroy's tamarin MHC class I chain		equivalent	protein	Geoffroy's tamarin MHC class I locus	
+Geoffroy's tamarin MHC class II chain		equivalent	protein	Geoffroy's tamarin MHC class II locus	
 Gogo-B chain		equivalent	protein	Gogo-B locus	
 Gogo-B*01:01 chain		subclass	Gogo-B chain		
+Guatemalan black howler MHC class I chain		equivalent	protein	Guatemalan black howler MHC class I locus	
+Guatemalan black howler MHC class II chain		equivalent	protein	Guatemalan black howler MHC class II locus	
+Guinea baboon MHC class I chain		equivalent	protein	Guinea baboon MHC class I locus	
+Guinea baboon MHC class II chain		equivalent	protein	Guinea baboon MHC class II locus	
 H2-D chain		equivalent	protein	H2-D locus	
 H2-Db chain		subclass	H2-D chain		
 H2-Dd chain		subclass	H2-D chain		
@@ -17908,6 +17922,8 @@ HLA-G*01:22 chain		subclass	HLA-G chain
 HLA-G*01:23 chain		subclass	HLA-G chain		
 HLA-G*01:24 chain		subclass	HLA-G chain		
 HLA-MR1 chain		equivalent	protein	HLA-MR1 locus	
+Japanese macaque MHC class I chain		equivalent	protein	Japanese macaque MHC class I locus	
+Japanese macaque MHC class II chain		equivalent	protein	Japanese macaque MHC class II locus	
 MHC class I chain		equivalent	protein	MHC class I locus	
 MHC class II chain		equivalent	protein	MHC class II locus	
 Mafa-A1 chain		equivalent	protein	Mafa-A1 locus	
@@ -19259,6 +19275,10 @@ Mamu-E*02:28 chain		subclass	Mamu-E chain
 Mamu-E*02:29 chain		subclass	Mamu-E chain		
 Mamu-E*02:30 chain		subclass	Mamu-E chain		
 Mamu-MR1 chain		equivalent	protein	Mamu-MR1 locus	
+Milne Edward's macaque MHC class I chain		equivalent	protein	Milne Edward's macaque MHC class I locus	
+Milne Edward's macaque MHC class II chain		equivalent	protein	Milne Edward's macaque MHC class II locus	
+Nancy Ma's night monkey MHC class I chain		equivalent	protein	Nancy Ma's night monkey MHC class I locus	
+Nancy Ma's night monkey MHC class II chain		equivalent	protein	Nancy Ma's night monkey MHC class II locus	
 Papa-A chain		equivalent	protein	Papa-A locus	
 Papa-A*06:01 chain		subclass	Papa-A chain		
 Patr-A chain		equivalent	protein	Patr-A locus	
@@ -20034,11 +20054,25 @@ SLA-DRB4*01:01 chain		subclass	SLA-DRB chain
 SLA-DRB5*01:01 chain		subclass	SLA-DRB chain		
 SLA-DRB chain		equivalent	protein	SLA-DRB locus	
 Saoe-G chain		equivalent	protein	Saoe-G locus	
+Spix's night monkey MHC class I chain		equivalent	protein	Spix's night monkey MHC class I locus	
+Spix's night monkey MHC class II chain		equivalent	protein	Spix's night monkey MHC class II locus	
+Sumatran orangutan MHC class I chain		equivalent	protein	Sumatran orangutan MHC class I locus	
+Sumatran orangutan MHC class II chain		equivalent	protein	Sumatran orangutan MHC class II locus	
 Xela-UAAg chain		equivalent	protein	Xela-UAAg locus	
 YF1w*7.1 chain		subclass	Gaga-BF-YF chain		
+black crested mangabey MHC class I chain		equivalent	protein	black crested mangabey MHC class I locus	
+black crested mangabey MHC class II chain		equivalent	protein	black crested mangabey MHC class II locus	
 black flying fox MHC class I chain		equivalent	protein	black flying fox MHC class I locus	
+black-headed night monkey MHC class I chain		equivalent	protein	black-headed night monkey MHC class I locus	
+black-headed night monkey MHC class II chain		equivalent	protein	black-headed night monkey MHC class II locus	
+black-headed spider monkey MHC class I chain		equivalent	protein	black-headed spider monkey MHC class I locus	
+black-headed spider monkey MHC class II chain		equivalent	protein	black-headed spider monkey MHC class II locus	
+blue monkey MHC class I chain		equivalent	protein	blue monkey MHC class I locus	
+blue monkey MHC class II chain		equivalent	protein	blue monkey MHC class II locus	
 bonobo MHC class I chain		equivalent	protein	bonobo MHC class I locus	
 bonobo MHC class II chain		equivalent	protein	bonobo MHC class II locus	
+brown-mantled tamarin MHC class I chain		equivalent	protein	brown-mantled tamarin MHC class I locus	
+brown-mantled tamarin MHC class II chain		equivalent	protein	brown-mantled tamarin MHC class II locus	
 cat MHC class I chain		equivalent	protein	cat MHC class I locus	
 cat MHC class II chain		equivalent	protein	cat MHC class II locus	
 cat non-classical MHC chain		equivalent	protein	cat non-classical MHC locus	
@@ -20048,6 +20082,8 @@ cattle MHC class I chain		equivalent	protein	cattle MHC class I locus
 cattle MHC class II chain		equivalent	protein	cattle MHC class II locus	
 cattle MR1 chain		subclass	BoLA-MR1 chain		
 cattle non-classical MHC chain		equivalent	protein	cattle non-classical MHC locus	
+chacma Baboon MHC class I chain		equivalent	protein	chacma Baboon MHC class I locus	
+chacma Baboon MHC class II chain		equivalent	protein	chacma Baboon MHC class II locus	
 chicken CD1-1 chain		subclass	Gaga-BF-B chain		
 chicken CD1-2 chain		subclass	Gaga-BF-B chain		
 chicken MHC class I chain		equivalent	protein	chicken MHC class I locus	
@@ -20057,6 +20093,8 @@ chimpanzee MHC class I chain		equivalent	protein	chimpanzee MHC class I locus
 chimpanzee MHC class II chain		equivalent	protein	chimpanzee MHC class II locus	
 chimpanzee non-classical MHC chain		equivalent	protein	chimpanzee non-classical MHC locus	
 clawed frog MHC class I chain		equivalent	protein	clawed frog MHC class I locus	
+common squirrel monkey MHC class I chain		equivalent	protein	common squirrel monkey MHC class I locus	
+common squirrel monkey MHC class II chain		equivalent	protein	common squirrel monkey MHC class II locus	
 cotton-top tamarin MHC class I chain		equivalent	protein	cotton-top tamarin MHC class I locus	
 cotton-top tamarin MHC class II chain		equivalent	protein	cotton-top tamarin MHC class II locus	
 crab-eating macaque MHC class I chain		equivalent	protein	crab-eating macaque MHC class I locus	
@@ -20065,9 +20103,19 @@ dog MHC class I chain		equivalent	protein	dog MHC class I locus
 dog MHC class II chain		equivalent	protein	dog MHC class II locus	
 domestic sheep MHC class I chain		equivalent	protein	domestic sheep MHC class I locus	
 domestic sheep MHC class II chain		equivalent	protein	domestic sheep MHC class II locus	
+drill MHC class I chain		equivalent	protein	drill MHC class I locus	
+drill MHC class II chain		equivalent	protein	drill MHC class II locus	
 duck MHC class I chain		equivalent	protein	duck MHC class I locus	
+eastern gorilla MHC class I chain		equivalent	protein	eastern gorilla MHC class I locus	
+eastern gorilla MHC class II chain		equivalent	protein	eastern gorilla MHC class II locus	
+gelada MHC class I chain		equivalent	protein	gelada MHC class I locus	
+gelada MHC class II chain		equivalent	protein	gelada MHC class II locus	
 giant panda MHC class I chain		equivalent	protein	giant panda MHC class I locus	
 giant panda MHC class II chain		equivalent	protein	giant panda MHC class II locus	
+golden lion tamarin MHC class I chain		equivalent	protein	golden lion tamarin MHC class I locus	
+golden lion tamarin MHC class II chain		equivalent	protein	golden lion tamarin MHC class II locus	
+golden snub-nosed monkey MHC class I chain		equivalent	protein	golden snub-nosed monkey MHC class I locus	
+golden snub-nosed monkey MHC class II chain		equivalent	protein	golden snub-nosed monkey MHC class II locus	
 gorilla MHC class I chain		equivalent	protein	gorilla MHC class I locus	
 gorilla MHC class II chain		equivalent	protein	gorilla MHC class II locus	
 grass carp Beta-2-microglobulin chain		equivalent	protein	grass carp Beta-2-microglobulin locus	
@@ -20075,6 +20123,14 @@ grass carp Beta-2-microglobulin-1-II chain		subclass	grass carp Beta-2-microglob
 grass carp Beta-2-microglobulin-2 chain		subclass	grass carp Beta-2-microglobulin chain		
 grass carp MHC class I chain		equivalent	protein	grass carp MHC class I locus	
 grass carp MHC class II chain		equivalent	protein	grass carp MHC class II locus	
+gray-bellied night monkey MHC class I chain		equivalent	protein	gray-bellied night monkey MHC class I locus	
+gray-bellied night monkey MHC class II chain		equivalent	protein	gray-bellied night monkey MHC class II locus	
+green monkey MHC class I chain		equivalent	protein	green monkey MHC class I locus	
+green monkey MHC class II chain		equivalent	protein	green monkey MHC class II locus	
+grivet MHC class I chain		equivalent	protein	grivet MHC class I locus	
+grivet MHC class II chain		equivalent	protein	grivet MHC class II locus	
+hamadryas baboon MHC class I chain		equivalent	protein	hamadryas baboon MHC class I locus	
+hamadryas baboon MHC class II chain		equivalent	protein	hamadryas baboon MHC class II locus	
 horse MHC class I chain		equivalent	protein	horse MHC class I locus	
 horse MHC class II chain		equivalent	protein	horse MHC class II locus	
 human BTN3A1 chain		subclass	HLA-BTN3A chain		
@@ -20086,6 +20142,14 @@ human MHC class I chain		equivalent	protein	human MHC class I locus
 human MHC class II chain		equivalent	protein	human MHC class II locus	
 human MR1 chain		subclass	HLA-MR1 chain		
 human non-classical MHC chain		equivalent	protein	human non-classical MHC locus	
+lar gibbon MHC class I chain		equivalent	protein	lar gibbon MHC class I locus	
+lar gibbon MHC class II chain		equivalent	protein	lar gibbon MHC class II locus	
+lion-tailed macaque MHC class I chain		equivalent	protein	lion-tailed macaque MHC class I locus	
+lion-tailed macaque MHC class II chain		equivalent	protein	lion-tailed macaque MHC class II locus	
+mandrill MHC class I chain		equivalent	protein	mandrill MHC class I locus	
+mandrill MHC class II chain		equivalent	protein	mandrill MHC class II locus	
+mantled guereza MHC class I chain		equivalent	protein	mantled guereza MHC class I locus	
+mantled guereza MHC class II chain		equivalent	protein	mantled guereza MHC class II locus	
 marmoset MHC class I chain		equivalent	protein	marmoset MHC class I locus	
 mouse CD1d1 chain		subclass	mouse CD1d chain		
 mouse CD1d2 chain		subclass	mouse CD1d chain		
@@ -20094,9 +20158,19 @@ mouse MHC class I chain		equivalent	protein	mouse MHC class I locus
 mouse MHC class II chain		equivalent	protein	mouse MHC class II locus	
 mouse MR1 chain		subclass	H2-MR1 chain		
 mouse non-classical MHC chain		equivalent	protein	mouse non-classical MHC locus	
+moustached tamarin MHC class I chain		equivalent	protein	moustached tamarin MHC class I locus	
+moustached tamarin MHC class II chain		equivalent	protein	moustached tamarin MHC class II locus	
 non-classical MHC chain		equivalent	protein	non-classical MHC locus	
+northern pig-tailed macaque MHC class I chain		equivalent	protein	northern pig-tailed macaque MHC class I locus	
+northern pig-tailed macaque MHC class II chain		equivalent	protein	northern pig-tailed macaque MHC class II locus	
+northern plains gray langur MHC class I chain		equivalent	protein	northern plains gray langur MHC class I locus	
+northern plains gray langur MHC class II chain		equivalent	protein	northern plains gray langur MHC class II locus	
+olive baboon MHC class I chain		equivalent	protein	olive baboon MHC class I locus	
+olive baboon MHC class II chain		equivalent	protein	olive baboon MHC class II locus	
 pig MHC class I chain		equivalent	protein	pig MHC class I locus	
 pig MHC class II chain		equivalent	protein	pig MHC class II locus	
+pygmy marmoset MHC class I chain		equivalent	protein	pygmy marmoset MHC class I locus	
+pygmy marmoset MHC class II chain		equivalent	protein	pygmy marmoset MHC class II locus	
 rabbit MHC class I chain		equivalent	protein	rabbit MHC class I locus	
 rabbit MHC class II chain		equivalent	protein	rabbit MHC class II locus	
 rat CD1 chain		equivalent	protein	rat CD1 locus	
@@ -20104,9 +20178,33 @@ rat CD1d chain		subclass	rat CD1 chain
 rat MHC class I chain		equivalent	protein	rat MHC class I locus	
 rat MHC class II chain		equivalent	protein	rat MHC class II locus	
 rat non-classical MHC chain		equivalent	protein	rat non-classical MHC locus	
+red-bellied titi MHC class I chain		equivalent	protein	red-bellied titi MHC class I locus	
+red-bellied titi MHC class II chain		equivalent	protein	red-bellied titi MHC class II locus	
 rhesus macaque CD1b chain		subclass	Mamu-CD1 chain		
 rhesus macaque CD1c chain		subclass	Mamu-CD1 chain		
 rhesus macaque MHC class I chain		equivalent	protein	rhesus macaque MHC class I locus	
 rhesus macaque MHC class II chain		equivalent	protein	rhesus macaque MHC class II locus	
 rhesus macaque MR1 chain		subclass	Mamu-MR1 chain		
 rhesus macaque non-classical MHC chain		equivalent	protein	rhesus macaque non-classical MHC locus	
+silvery Javan gibbon MHC class I chain		equivalent	protein	silvery Javan gibbon MHC class I locus	
+silvery Javan gibbon MHC class II chain		equivalent	protein	silvery Javan gibbon MHC class II locus	
+sooty mangabey MHC class I chain		equivalent	protein	sooty mangabey MHC class I locus	
+sooty mangabey MHC class II chain		equivalent	protein	sooty mangabey MHC class II locus	
+southern pig-tailed macaque MHC class I chain		equivalent	protein	southern pig-tailed macaque MHC class I locus	
+southern pig-tailed macaque MHC class II chain		equivalent	protein	southern pig-tailed macaque MHC class II locus	
+stump-tailed macaque MHC class I chain		equivalent	protein	stump-tailed macaque MHC class I locus	
+stump-tailed macaque MHC class II chain		equivalent	protein	stump-tailed macaque MHC class II locus	
+three-striped night monkey MHC class I chain		equivalent	protein	three-striped night monkey MHC class I locus	
+three-striped night monkey MHC class II chain		equivalent	protein	three-striped night monkey MHC class II locus	
+tufted capuchin MHC class I chain		equivalent	protein	tufted capuchin MHC class I locus	
+tufted capuchin MHC class II chain		equivalent	protein	tufted capuchin MHC class II locus	
+vervet monkey MHC class I chain		equivalent	protein	vervet monkey MHC class I locus	
+vervet monkey MHC class II chain		equivalent	protein	vervet monkey MHC class II locus	
+white-faced saki MHC class I chain		equivalent	protein	white-faced saki MHC class I locus	
+white-faced saki MHC class II chain		equivalent	protein	white-faced saki MHC class II locus	
+white-fronted spider monkey MHC class I chain		equivalent	protein	white-fronted spider monkey MHC class I locus	
+white-fronted spider monkey MHC class II chain		equivalent	protein	white-fronted spider monkey MHC class II locus	
+white-lipped tamarin MHC class I chain		equivalent	protein	white-lipped tamarin MHC class I locus	
+white-lipped tamarin MHC class II chain		equivalent	protein	white-lipped tamarin MHC class II locus	
+yellow baboon MHC class I chain		equivalent	protein	yellow baboon MHC class I locus	
+yellow baboon MHC class II chain		equivalent	protein	yellow baboon MHC class II locus	

--- a/ontology/external.tsv
+++ b/ontology/external.tsv
@@ -10,12 +10,36 @@ NCBITaxon:8839	duck	Anas platyrhynchos		subclass	organism					http://purl.obolib
 NCBITaxon:9031	chicken	Gallus gallus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Gaga
 NCBITaxon:9402	black flying fox	Pteropus alecto		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ptal
 NCBITaxon:9483	marmoset	Callithrix jacchus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Caja
+NCBITaxon:9487	brown-mantled tamarin	Leontocebus fuscicollis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Safu
+NCBITaxon:9488	moustached tamarin	Saguinus mystax		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Samy
 NCBITaxon:9490	cotton-top tamarin	Saguinus oedipus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Saoe
+NCBITaxon:9493	pygmy marmoset	Cebuella pygmaea		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Capy
+NCBITaxon:9505	three-striped night monkey	Aotus trivirgatus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Aotr
+NCBITaxon:9507	white-fronted spider monkey	Ateles belzebuth		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Atbe
+NCBITaxon:9508	black-headed spider monkey	Ateles fusciceps		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Atfu
+NCBITaxon:9515	tufted capuchin	Sapajus apella		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ceap
+NCBITaxon:9521	common squirrel monkey	Saimiri sciureus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Sasc
+NCBITaxon:9523	red-bellied titi	Plecturocebus moloch		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Camo
+NCBITaxon:9531	sooty mangabey	Cercocebus atys		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ceat
+NCBITaxon:9534	grivet	Chlorocebus aethiops		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Chae
+NCBITaxon:9540	stump-tailed macaque	Macaca arctoides		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Maar
 NCBITaxon:9541	crab-eating macaque	Macaca fascicularis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Mafa
+NCBITaxon:9542	Japanese macaque	Macaca fuscata		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Mafu
 NCBITaxon:9544	rhesus macaque	Macaca mulatta		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Mamu
+NCBITaxon:9545	southern pig-tailed macaque	Macaca nemestrina		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Mane
+NCBITaxon:9551	Assam macaque	Macaca assamensis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Maas
+NCBITaxon:9555	olive baboon	Papio anubis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Paan
+NCBITaxon:9556	yellow baboon	Papio cynocephalus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Pacy
+NCBITaxon:9557	hamadryas baboon	Papio hamadryas		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Paha
+NCBITaxon:9561	mandrill	Mandrillus sphinx		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Masp
+NCBITaxon:9565	gelada	Theropithecus gelada		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Thge
+NCBITaxon:9568	drill	Mandrillus leucophaeus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Male
+NCBITaxon:9580	lar gibbon	Hylobates lar		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Hyla
 NCBITaxon:9593	gorilla	Gorilla gorilla		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Gogo
 NCBITaxon:9597	bonobo	Pan paniscus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Papa
 NCBITaxon:9598	chimpanzee	Pan troglodytes		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Patr
+NCBITaxon:9600	Bornean orangutan	Pongo pygmaeus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Popy
+NCBITaxon:9601	Sumatran orangutan	Pongo abelii		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Poab
 NCBITaxon:9606	human	Homo sapiens		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	HLA
 NCBITaxon:9615	dog	Canis lupus familiaris		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	DLA
 NCBITaxon:9646	giant panda	Ailuropoda melanoleuca		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Amie
@@ -28,7 +52,32 @@ NCBITaxon:9940	domestic sheep	Ovis aries		subclass	organism					http://purl.obol
 NCBITaxon:9986	rabbit	Oryctolagus cuniculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	RLA
 NCBITaxon:10090	mouse	Mus musculus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	H2
 NCBITaxon:10116	rat	Rattus norvegicus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	RT1
+NCBITaxon:30588	golden lion tamarin	Leontopithecus rosalia		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Lero
+NCBITaxon:30591	Azara's night monkey	Aotus azarai		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Aoaz
+NCBITaxon:33548	mantled guereza	Colobus guereza		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Cogu
+NCBITaxon:36225	blue monkey	Cercopithecus mitis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Cemi
+NCBITaxon:36227	De Brazza's monkey	Cercopithecus neglectus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Cene
+NCBITaxon:36229	chacma Baboon	Papio ursinus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Paur
 NCBITaxon:37174	bighorn sheep	Ovis canadensis		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Ovca
+NCBITaxon:37293	Nancy Ma's night monkey	Aotus nancymaae		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Aona
+NCBITaxon:43147	gray-bellied night monkey	Aotus lemurinus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Aole
+NCBITaxon:43777	white-faced saki	Pithecia pithecia		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Pipi
+NCBITaxon:43778	Geoffroy's tamarin	Saguinus geoffroyi		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Sage
+NCBITaxon:54601	lion-tailed macaque	Macaca silenus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Masi
+NCBITaxon:54602	Milne Edward's macaque	Macaca thibetana		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Math
+NCBITaxon:57175	black-headed night monkey	Aotus nigriceps		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Aoni
+NCBITaxon:57176	Spix's night monkey	Aotus vociferans		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Aovo
+NCBITaxon:60710	vervet monkey	Chlorocebus pygerythrus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Chpy
+NCBITaxon:60711	green monkey	Chlorocebus sabaeus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Chsa
+NCBITaxon:61622	golden snub-nosed monkey	Rhinopithecus roxellana		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Rhro
+NCBITaxon:75566	black crested mangabey	Lophocebus aterrimus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Loat
+NCBITaxon:78454	white-lipped tamarin	Saguinus labiatus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Sala
+NCBITaxon:81572	silvery Javan gibbon	Hylobates moloch		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Hymo
+NCBITaxon:88029	northern plains gray langur	Semnopithecus entellus		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Seen
+NCBITaxon:90387	northern pig-tailed macaque	Macaca leonina		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Malo
+NCBITaxon:100937	Guinea baboon	Papio papio		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Papp
+NCBITaxon:182253	Guatemalan black howler	Alouatta pigra		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Alpi
+NCBITaxon:499232	eastern gorilla	Gorilla beringei		subclass	organism					http://purl.obolibrary.org/obo/ncbitaxon.owl	Gobe
 PR:000000001	protein	protein		subclass	material entity					http://purl.obolibrary.org/obo/pr.owl	
 PR:000004580	Beta-2-microglobulin	Beta-2-microglobulin		equivalent	protein	('gene product of' some 'Beta-2-microglobulin locus')	A protein that is a translation product of the human B2M gene or a 1:1 ortholog thereof.			http://purl.obolibrary.org/obo/pr.owl	
 REO:0000079	genetic locus	genetic locus		subclass	genetic entity		a nucleic acid sequence region that is part of a genome and represents a specified location or region on a chromosome or other genomic element.			http://purl.obolibrary.org/obo/reo.owl	

--- a/ontology/genetic-locus.tsv
+++ b/ontology/genetic-locus.tsv
@@ -2,6 +2,10 @@ Label	Synonyms	Class Type	Parent	In Taxon
 LABEL	A IAO:0000118 SPLIT=|	CLASS_TYPE	C %	C 'in taxon' some %
 Aime-128 locus		subclass	giant panda MHC class I locus	
 Anpl-UAA locus		subclass	duck MHC class I locus	
+Assam macaque MHC class I locus		subclass	MHC class I locus	Assam macaque
+Assam macaque MHC class II locus		subclass	MHC class II locus	Assam macaque
+Azara's night monkey MHC class I locus		subclass	MHC class I locus	Azara's night monkey
+Azara's night monkey MHC class II locus		subclass	MHC class II locus	Azara's night monkey
 BoLA-1 locus		subclass	cattle MHC class I locus	
 BoLA-2 locus		subclass	cattle MHC class I locus	
 BoLA-3 locus		subclass	cattle MHC class I locus	
@@ -20,10 +24,14 @@ BoLA-NC1 locus		subclass	cattle non-classical MHC locus
 BoLA-NC2 locus		subclass	cattle non-classical MHC locus	
 BoLA-NC3 locus		subclass	cattle non-classical MHC locus	
 BoLA-NC4 locus		subclass	cattle non-classical MHC locus	
+Bornean orangutan MHC class I locus		subclass	MHC class I locus	Bornean orangutan
+Bornean orangutan MHC class II locus		subclass	MHC class II locus	Bornean orangutan
 Caja-E locus		subclass	marmoset MHC class I locus	
 Caja-G locus		subclass	marmoset MHC class I locus	
 Ctid-UAA locus		subclass	grass carp MHC class I locus	
 DLA-88 locus		subclass	dog MHC class I locus	
+De Brazza's monkey MHC class I locus		subclass	MHC class I locus	De Brazza's monkey
+De Brazza's monkey MHC class II locus		subclass	MHC class II locus	De Brazza's monkey
 ELA-1 locus		subclass	horse MHC class I locus	
 ELA-16 locus		subclass	horse MHC class I locus	
 ELA-N locus		subclass	horse MHC class I locus	
@@ -32,7 +40,13 @@ Gaga-BF1 locus		subclass	chicken MHC class I locus
 Gaga-BF2 locus		subclass	chicken MHC class I locus	
 Gaga-BF-B locus		subclass	chicken non-classical MHC locus	
 Gaga-BF-YF locus		subclass	chicken non-classical MHC locus	
+Geoffroy's tamarin MHC class I locus		subclass	MHC class I locus	Geoffroy's tamarin
+Geoffroy's tamarin MHC class II locus		subclass	MHC class II locus	Geoffroy's tamarin
 Gogo-B locus		subclass	gorilla MHC class I locus	
+Guatemalan black howler MHC class I locus		subclass	MHC class I locus	Guatemalan black howler
+Guatemalan black howler MHC class II locus		subclass	MHC class II locus	Guatemalan black howler
+Guinea baboon MHC class I locus		subclass	MHC class I locus	Guinea baboon
+Guinea baboon MHC class II locus		subclass	MHC class II locus	Guinea baboon
 H2-D locus		subclass	mouse MHC class I locus	
 H2-IA alpha locus		subclass	mouse MHC class II locus	
 H2-IA beta locus		subclass	mouse MHC class II locus	
@@ -65,6 +79,8 @@ HLA-E locus		subclass	human non-classical MHC locus
 HLA-F locus		subclass	human non-classical MHC locus	
 HLA-G locus		subclass	human non-classical MHC locus	
 HLA-MR1 locus		subclass	human non-classical MHC locus	
+Japanese macaque MHC class I locus		subclass	MHC class I locus	Japanese macaque
+Japanese macaque MHC class II locus		subclass	MHC class II locus	Japanese macaque
 MHC class I locus		subclass	MHC locus	
 MHC class II locus		subclass	MHC locus	
 Mafa-A1 locus		subclass	crab-eating macaque MHC class I locus	
@@ -83,6 +99,10 @@ Mamu-DRA locus		subclass	rhesus macaque MHC class II locus
 Mamu-DRB locus		subclass	rhesus macaque MHC class II locus	
 Mamu-E locus		subclass	rhesus macaque MHC class I locus	
 Mamu-MR1 locus		subclass	rhesus macaque non-classical MHC locus	
+Milne Edward's macaque MHC class I locus		subclass	MHC class I locus	Milne Edward's macaque
+Milne Edward's macaque MHC class II locus		subclass	MHC class II locus	Milne Edward's macaque
+Nancy Ma's night monkey MHC class I locus		subclass	MHC class I locus	Nancy Ma's night monkey
+Nancy Ma's night monkey MHC class II locus		subclass	MHC class II locus	Nancy Ma's night monkey
 Papa-A locus		subclass	bonobo MHC class I locus	
 Patr-A locus		subclass	chimpanzee MHC class I locus	
 Patr-AL locus		subclass	chimpanzee non-classical MHC locus	
@@ -112,16 +132,32 @@ SLA-DQB locus		subclass	pig MHC class II locus
 SLA-DRA locus		subclass	pig MHC class II locus	
 SLA-DRB locus		subclass	pig MHC class II locus	
 Saoe-G locus		subclass	cotton-top tamarin MHC class I locus	
+Spix's night monkey MHC class I locus		subclass	MHC class I locus	Spix's night monkey
+Spix's night monkey MHC class II locus		subclass	MHC class II locus	Spix's night monkey
+Sumatran orangutan MHC class I locus		subclass	MHC class I locus	Sumatran orangutan
+Sumatran orangutan MHC class II locus		subclass	MHC class II locus	Sumatran orangutan
 Xela-UAAg locus		subclass	clawed frog MHC class I locus	
+black crested mangabey MHC class I locus		subclass	MHC class I locus	black crested mangabey
+black crested mangabey MHC class II locus		subclass	MHC class II locus	black crested mangabey
 black flying fox MHC class I locus		subclass	MHC class I locus	black flying fox
+black-headed night monkey MHC class I locus		subclass	MHC class I locus	black-headed night monkey
+black-headed night monkey MHC class II locus		subclass	MHC class II locus	black-headed night monkey
+black-headed spider monkey MHC class I locus		subclass	MHC class I locus	black-headed spider monkey
+black-headed spider monkey MHC class II locus		subclass	MHC class II locus	black-headed spider monkey
+blue monkey MHC class I locus		subclass	MHC class I locus	blue monkey
+blue monkey MHC class II locus		subclass	MHC class II locus	blue monkey
 bonobo MHC class I locus		subclass	MHC class I locus	bonobo
 bonobo MHC class II locus		subclass	MHC class II locus	bonobo
+brown-mantled tamarin MHC class I locus		subclass	MHC class I locus	brown-mantled tamarin
+brown-mantled tamarin MHC class II locus		subclass	MHC class II locus	brown-mantled tamarin
 cat MHC class I locus		subclass	MHC class I locus	cat
 cat MHC class II locus		subclass	MHC class II locus	cat
 cat non-classical MHC locus		subclass	non-classical MHC locus	cat
 cattle MHC class I locus		subclass	MHC class I locus	cattle
 cattle MHC class II locus		subclass	MHC class II locus	cattle
 cattle non-classical MHC locus		subclass	non-classical MHC locus	cattle
+chacma Baboon MHC class I locus		subclass	MHC class I locus	chacma Baboon
+chacma Baboon MHC class II locus		subclass	MHC class II locus	chacma Baboon
 chicken MHC class I locus		subclass	MHC class I locus	chicken
 chicken MHC class II locus		subclass	MHC class II locus	chicken
 chicken non-classical MHC locus		subclass	non-classical MHC locus	chicken
@@ -130,6 +166,8 @@ chimpanzee MHC class II locus		subclass	MHC class II locus	chimpanzee
 chimpanzee non-classical MHC locus		subclass	non-classical MHC locus	chimpanzee
 clawed frog MHC class I locus		subclass	MHC class I locus	clawed frog
 clawed frog MHC class II locus		subclass	MHC class II locus	clawed frog
+common squirrel monkey MHC class I locus		subclass	MHC class I locus	common squirrel monkey
+common squirrel monkey MHC class II locus		subclass	MHC class II locus	common squirrel monkey
 cotton-top tamarin MHC class I locus		subclass	MHC class I locus	cotton-top tamarin
 cotton-top tamarin MHC class II locus		subclass	MHC class II locus	cotton-top tamarin
 crab-eating macaque MHC class I locus		subclass	MHC class I locus	crab-eating macaque
@@ -138,33 +176,93 @@ dog MHC class I locus		subclass	MHC class I locus	dog
 dog MHC class II locus		subclass	MHC class II locus	dog
 domestic sheep MHC class I locus		subclass	MHC class I locus	domestic sheep
 domestic sheep MHC class II locus		subclass	MHC class II locus	domestic sheep
+drill MHC class I locus		subclass	MHC class I locus	drill
+drill MHC class II locus		subclass	MHC class II locus	drill
 duck MHC class I locus		subclass	MHC class I locus	duck
+eastern gorilla MHC class I locus		subclass	MHC class I locus	eastern gorilla
+eastern gorilla MHC class II locus		subclass	MHC class II locus	eastern gorilla
+gelada MHC class I locus		subclass	MHC class I locus	gelada
+gelada MHC class II locus		subclass	MHC class II locus	gelada
 giant panda MHC class I locus		subclass	MHC class I locus	giant panda
 giant panda MHC class II locus		subclass	MHC class II locus	giant panda
+golden lion tamarin MHC class I locus		subclass	MHC class I locus	golden lion tamarin
+golden lion tamarin MHC class II locus		subclass	MHC class II locus	golden lion tamarin
+golden snub-nosed monkey MHC class I locus		subclass	MHC class I locus	golden snub-nosed monkey
+golden snub-nosed monkey MHC class II locus		subclass	MHC class II locus	golden snub-nosed monkey
 gorilla MHC class I locus		subclass	MHC class I locus	gorilla
 gorilla MHC class II locus		subclass	MHC class II locus	gorilla
 grass carp Beta-2-microglobulin locus		subclass	Beta-2-microglobulin locus	grass carp
 grass carp MHC class I locus		subclass	MHC class I locus	grass carp
 grass carp MHC class II locus		subclass	MHC class II locus	grass carp
+gray-bellied night monkey MHC class I locus		subclass	MHC class I locus	gray-bellied night monkey
+gray-bellied night monkey MHC class II locus		subclass	MHC class II locus	gray-bellied night monkey
+green monkey MHC class I locus		subclass	MHC class I locus	green monkey
+green monkey MHC class II locus		subclass	MHC class II locus	green monkey
+grivet MHC class I locus		subclass	MHC class I locus	grivet
+grivet MHC class II locus		subclass	MHC class II locus	grivet
+hamadryas baboon MHC class I locus		subclass	MHC class I locus	hamadryas baboon
+hamadryas baboon MHC class II locus		subclass	MHC class II locus	hamadryas baboon
 horse MHC class I locus		subclass	MHC class I locus	horse
 horse MHC class II locus		subclass	MHC class II locus	horse
 human MHC class I locus		subclass	MHC class I locus	human
 human MHC class II locus		subclass	MHC class II locus	human
 human non-classical MHC locus		subclass	non-classical MHC locus	human
+lar gibbon MHC class I locus		subclass	MHC class I locus	lar gibbon
+lar gibbon MHC class II locus		subclass	MHC class II locus	lar gibbon
+lion-tailed macaque MHC class I locus		subclass	MHC class I locus	lion-tailed macaque
+lion-tailed macaque MHC class II locus		subclass	MHC class II locus	lion-tailed macaque
+mandrill MHC class I locus		subclass	MHC class I locus	mandrill
+mandrill MHC class II locus		subclass	MHC class II locus	mandrill
+mantled guereza MHC class I locus		subclass	MHC class I locus	mantled guereza
+mantled guereza MHC class II locus		subclass	MHC class II locus	mantled guereza
 marmoset MHC class I locus		subclass	MHC class I locus	marmoset
 mouse CD1d locus		subclass	mouse non-classical MHC locus	
 mouse MHC class I locus		subclass	MHC class I locus	mouse
 mouse MHC class II locus		subclass	MHC class II locus	mouse
 mouse non-classical MHC locus		subclass	non-classical MHC locus	mouse
+moustached tamarin MHC class I locus		subclass	MHC class I locus	moustached tamarin
+moustached tamarin MHC class II locus		subclass	MHC class II locus	moustached tamarin
 non-classical MHC locus		subclass	MHC locus	
+northern pig-tailed macaque MHC class I locus		subclass	MHC class I locus	northern pig-tailed macaque
+northern pig-tailed macaque MHC class II locus		subclass	MHC class II locus	northern pig-tailed macaque
+northern plains gray langur MHC class I locus		subclass	MHC class I locus	northern plains gray langur
+northern plains gray langur MHC class II locus		subclass	MHC class II locus	northern plains gray langur
+olive baboon MHC class I locus		subclass	MHC class I locus	olive baboon
+olive baboon MHC class II locus		subclass	MHC class II locus	olive baboon
 pig MHC class I locus		subclass	MHC class I locus	pig
 pig MHC class II locus		subclass	MHC class II locus	pig
+pygmy marmoset MHC class I locus		subclass	MHC class I locus	pygmy marmoset
+pygmy marmoset MHC class II locus		subclass	MHC class II locus	pygmy marmoset
 rabbit MHC class I locus		subclass	MHC class I locus	rabbit
 rabbit MHC class II locus		subclass	MHC class II locus	rabbit
 rat CD1 locus		subclass	rat non-classical MHC locus	rat
 rat MHC class I locus		subclass	MHC class I locus	rat
 rat MHC class II locus		subclass	MHC class II locus	rat
 rat non-classical MHC locus		subclass	non-classical MHC locus	rat
+red-bellied titi MHC class I locus		subclass	MHC class I locus	red-bellied titi
+red-bellied titi MHC class II locus		subclass	MHC class II locus	red-bellied titi
 rhesus macaque MHC class I locus		subclass	MHC class I locus	rhesus macaque
 rhesus macaque MHC class II locus		subclass	MHC class II locus	rhesus macaque
 rhesus macaque non-classical MHC locus		subclass	non-classical MHC locus	rhesus macaque
+silvery Javan gibbon MHC class I locus		subclass	MHC class I locus	silvery Javan gibbon
+silvery Javan gibbon MHC class II locus		subclass	MHC class II locus	silvery Javan gibbon
+sooty mangabey MHC class I locus		subclass	MHC class I locus	sooty mangabey
+sooty mangabey MHC class II locus		subclass	MHC class II locus	sooty mangabey
+southern pig-tailed macaque MHC class I locus		subclass	MHC class I locus	southern pig-tailed macaque
+southern pig-tailed macaque MHC class II locus		subclass	MHC class II locus	southern pig-tailed macaque
+stump-tailed macaque MHC class I locus		subclass	MHC class I locus	stump-tailed macaque
+stump-tailed macaque MHC class II locus		subclass	MHC class II locus	stump-tailed macaque
+three-striped night monkey MHC class I locus		subclass	MHC class I locus	three-striped night monkey
+three-striped night monkey MHC class II locus		subclass	MHC class II locus	three-striped night monkey
+tufted capuchin MHC class I locus		subclass	MHC class I locus	tufted capuchin
+tufted capuchin MHC class II locus		subclass	MHC class II locus	tufted capuchin
+vervet monkey MHC class I locus		subclass	MHC class I locus	vervet monkey
+vervet monkey MHC class II locus		subclass	MHC class II locus	vervet monkey
+white-faced saki MHC class I locus		subclass	MHC class I locus	white-faced saki
+white-faced saki MHC class II locus		subclass	MHC class II locus	white-faced saki
+white-fronted spider monkey MHC class I locus		subclass	MHC class I locus	white-fronted spider monkey
+white-fronted spider monkey MHC class II locus		subclass	MHC class II locus	white-fronted spider monkey
+white-lipped tamarin MHC class I locus		subclass	MHC class I locus	white-lipped tamarin
+white-lipped tamarin MHC class II locus		subclass	MHC class II locus	white-lipped tamarin
+yellow baboon MHC class I locus		subclass	MHC class I locus	yellow baboon
+yellow baboon MHC class II locus		subclass	MHC class II locus	yellow baboon

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -4,6 +4,10 @@ Aime-128 protein complex	Aime-128		locus	equivalent	MHC class I protein complex	
 Anpl-UAA protein complex	Anpl-UAA		locus	equivalent	MHC class I protein complex	duck	Anpl-UAA chain	Beta-2-microglobulin		
 Anpl-UAA*01 protein complex	Anpl-UAA*01		complete molecule	equivalent	MHC class I protein complex	duck	Anpl-UAA*01 chain	Beta-2-microglobulin		
 Anpl-UAA*SD protein complex	Anpl-UAA*SD		complete molecule	equivalent	MHC class I protein complex	duck	Anpl-UAA*SD chain	Beta-2-microglobulin		
+Assam macaque MHC class I protein complex	Assam macaque		class	equivalent	MHC class I protein complex	Assam macaque				
+Assam macaque MHC class II protein complex	Assam macaque		class	equivalent	MHC class II protein complex	Assam macaque				
+Azara's night monkey MHC class I protein complex	Azara's night monkey		class	equivalent	MHC class I protein complex	Azara's night monkey				
+Azara's night monkey MHC class II protein complex	Azara's night monkey		class	equivalent	MHC class II protein complex	Azara's night monkey				
 BoLA-1 protein complex	BoLA-1		locus	equivalent	MHC class I protein complex	cattle	BoLA-1 chain	Beta-2-microglobulin		
 BoLA-1*007:01 protein complex	BoLA-1*007:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-1*007:01 chain	Beta-2-microglobulin		
 BoLA-1*009:01 protein complex	BoLA-1*009:01		complete molecule	equivalent	MHC class I protein complex	cattle	BoLA-1*009:01 chain	Beta-2-microglobulin		
@@ -697,6 +701,8 @@ BoLA-NC4*001:01 protein complex	BoLA-NC4*001:01		complete molecule	equivalent	no
 BoLA-NC4*002:01 protein complex	BoLA-NC4*002:01		complete molecule	equivalent	non-classical MHC protein complex	cattle	BoLA-NC4*002:01 chain	Beta-2-microglobulin		
 BoLA-NC4*002:02 protein complex	BoLA-NC4*002:02		complete molecule	equivalent	non-classical MHC protein complex	cattle	BoLA-NC4*002:02 chain	Beta-2-microglobulin		
 BoLA-NC4*003:01 protein complex	BoLA-NC4*003:01		complete molecule	equivalent	non-classical MHC protein complex	cattle	BoLA-NC4*003:01 chain	Beta-2-microglobulin		
+Bornean orangutan MHC class I protein complex	Bornean orangutan		class	equivalent	MHC class I protein complex	Bornean orangutan				
+Bornean orangutan MHC class II protein complex	Bornean orangutan		class	equivalent	MHC class II protein complex	Bornean orangutan				
 Caja-E protein complex	Caja-E		locus	equivalent	MHC class I protein complex	marmoset	Caja-E chain	Beta-2-microglobulin		
 Caja-G protein complex	Caja-G		locus	equivalent	MHC class I protein complex	marmoset	Caja-G chain	Beta-2-microglobulin		
 Ctid-UAA b2m-1-II protein complex	Ctid-UAA b2m-1-II		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-1-II chain		
@@ -705,6 +711,8 @@ DLA-88 protein complex	DLA-88		locus	equivalent	MHC class I protein complex	dog	
 DLA-88*034:01 protein complex	DLA-88*034:01		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*034:01 chain	Beta-2-microglobulin		
 DLA-88*501:01 protein complex	DLA-88*501:01		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*501:01 chain	Beta-2-microglobulin		
 DLA-88*508:01 protein complex	DLA-88*508:01	dla88-21	complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*508:01 chain	Beta-2-microglobulin		
+De Brazza's monkey MHC class I protein complex	De Brazza's monkey		class	equivalent	MHC class I protein complex	De Brazza's monkey				
+De Brazza's monkey MHC class II protein complex	De Brazza's monkey		class	equivalent	MHC class II protein complex	De Brazza's monkey				
 ELA-N protein complex	ELA-N		locus	equivalent	MHC class I protein complex	horse	ELA-N chain	Beta-2-microglobulin		
 Eqca-1*001:01 protein complex	Eqca-1*001:01	ELA-A3.1	complete molecule	equivalent	MHC class I protein complex	horse	Eqca-1*001:01 chain	Beta-2-microglobulin	A3 haplotype	
 Eqca-1*002:01 protein complex	Eqca-1*002:01		complete molecule	equivalent	MHC class I protein complex	horse	Eqca-1*002:01 chain	Beta-2-microglobulin		
@@ -724,8 +732,14 @@ Gaga-BF2*014:01 protein complex	Gaga-BF2*014:01	BF2*1401|BF2*014:01|BFCC12a|BFCC
 Gaga-BF2*015:01 protein complex	Gaga-BF2*015:01	BF2*1501|BF2*015:01|BFIV15	complete molecule	equivalent	MHC class I protein complex	chicken	Gaga-BF2*015:01 chain	Beta-2-microglobulin	B15 haplotype	
 Gaga-BF2*021:01 protein complex	Gaga-BF2*021:01	BF2*2101|BF2*021:01|BFIV21|BF2*131|BF2*W1|BFCC2a|BFCC15-1	complete molecule	equivalent	MHC class I protein complex	chicken	Gaga-BF2*021:01 chain	Beta-2-microglobulin	B21 haplotype	
 Gaga-BF2*1301 protein complex	Gaga-BF2*1301		complete molecule	equivalent	MHC class I protein complex	chicken	Gaga-BF2*1301 chain	Beta-2-microglobulin	B13 haplotype	
+Geoffroy's tamarin MHC class I protein complex	Geoffroy's tamarin		class	equivalent	MHC class I protein complex	Geoffroy's tamarin				
+Geoffroy's tamarin MHC class II protein complex	Geoffroy's tamarin		class	equivalent	MHC class II protein complex	Geoffroy's tamarin				
 Gogo-B protein complex	Gogo-B		locus	equivalent	MHC class I protein complex	gorilla	Gogo-B chain	Beta-2-microglobulin		
 Gogo-B*01:01 protein complex	Gogo-B*01:01		complete molecule	equivalent	MHC class I protein complex	gorilla	Gogo-B*01:01 chain	Beta-2-microglobulin		
+Guatemalan black howler MHC class I protein complex	Guatemalan black howler		class	equivalent	MHC class I protein complex	Guatemalan black howler				
+Guatemalan black howler MHC class II protein complex	Guatemalan black howler		class	equivalent	MHC class II protein complex	Guatemalan black howler				
+Guinea baboon MHC class I protein complex	Guinea baboon		class	equivalent	MHC class I protein complex	Guinea baboon				
+Guinea baboon MHC class II protein complex	Guinea baboon		class	equivalent	MHC class II protein complex	Guinea baboon				
 H2-D protein complex	H2-D		locus	equivalent	MHC class I protein complex	mouse	H2-D chain	Beta-2-microglobulin		
 H2-Db protein complex	H2-Db		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Db chain	Beta-2-microglobulin	H2-b haplotype	
 H2-Dd protein complex	H2-Dd		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Dd chain	Beta-2-microglobulin	H2-d haplotype	
@@ -22861,6 +22875,8 @@ HLA-G*01:20 protein complex	HLA-G*01:20		complete molecule	equivalent	non-classi
 HLA-G*01:22 protein complex	HLA-G*01:22		complete molecule	equivalent	non-classical MHC protein complex	human	HLA-G*01:22 chain	Beta-2-microglobulin		
 HLA-G*01:23 protein complex	HLA-G*01:23		complete molecule	equivalent	non-classical MHC protein complex	human	HLA-G*01:23 chain	Beta-2-microglobulin		
 HLA-G*01:24 protein complex	HLA-G*01:24		complete molecule	equivalent	non-classical MHC protein complex	human	HLA-G*01:24 chain	Beta-2-microglobulin		
+Japanese macaque MHC class I protein complex	Japanese macaque		class	equivalent	MHC class I protein complex	Japanese macaque				
+Japanese macaque MHC class II protein complex	Japanese macaque		class	equivalent	MHC class II protein complex	Japanese macaque				
 MHC class I protein complex	class I		class	subclass	MHC protein complex					
 MHC class II protein complex	class II		class	subclass	MHC protein complex					
 Mafa-A1 protein complex	Mafa-A1		locus	equivalent	MHC class I protein complex	crab-eating macaque	Mafa-A1 chain	Beta-2-microglobulin		
@@ -24206,6 +24222,10 @@ Mamu-E*02:28 protein complex	Mamu-E*02:28		complete molecule	equivalent	MHC clas
 Mamu-E*02:29 protein complex	Mamu-E*02:29		complete molecule	equivalent	MHC class I protein complex	rhesus macaque	Mamu-E*02:29 chain	Beta-2-microglobulin		
 Mamu-E*02:30 protein complex	Mamu-E*02:30		complete molecule	equivalent	MHC class I protein complex	rhesus macaque	Mamu-E*02:30 chain	Beta-2-microglobulin		
 Mamu-MR1 protein complex	Mamu-MR1		complete molecule	equivalent	non-classical MHC protein complex	rhesus macaque	Mamu-MR1 chain	Beta-2-microglobulin		
+Milne Edward's macaque MHC class I protein complex	Milne Edward's macaque		class	equivalent	MHC class I protein complex	Milne Edward's macaque				
+Milne Edward's macaque MHC class II protein complex	Milne Edward's macaque		class	equivalent	MHC class II protein complex	Milne Edward's macaque				
+Nancy Ma's night monkey MHC class I protein complex	Nancy Ma's night monkey		class	equivalent	MHC class I protein complex	Nancy Ma's night monkey				
+Nancy Ma's night monkey MHC class II protein complex	Nancy Ma's night monkey		class	equivalent	MHC class II protein complex	Nancy Ma's night monkey				
 Papa-A protein complex	Papa-A		locus	equivalent	MHC class I protein complex	bonobo	Papa-A chain	Beta-2-microglobulin		
 Papa-A*06:01 protein complex	Papa-A*06:01	Papa-A06	complete molecule	equivalent	MHC class I protein complex	bonobo	Papa-A*06:01 chain	Beta-2-microglobulin		
 Patr-A protein complex	Patr-A		locus	equivalent	MHC class I protein complex	chimpanzee	Patr-A chain	Beta-2-microglobulin		
@@ -24962,16 +24982,30 @@ SLA-DRB3*05:01 protein complex	SLA-DRB3*05:01		partial molecule	equivalent	MHC c
 SLA-DRB4*01:01 protein complex	SLA-DRB4*01:01		partial molecule	equivalent	MHC class II protein complex	pig	SLA-DRA chain	SLA-DRB4*01:01 chain		
 SLA-DRB5*01:01 protein complex	SLA-DRB5*01:01		partial molecule	equivalent	MHC class II protein complex	pig	SLA-DRA chain	SLA-DRB5*01:01 chain		
 Saoe-G protein complex	Saoe-G		locus	equivalent	MHC class I protein complex	cotton-top tamarin	Saoe-G chain	Beta-2-microglobulin		
+Spix's night monkey MHC class I protein complex	Spix's night monkey		class	equivalent	MHC class I protein complex	Spix's night monkey				
+Spix's night monkey MHC class II protein complex	Spix's night monkey		class	equivalent	MHC class II protein complex	Spix's night monkey				
+Sumatran orangutan MHC class I protein complex	Sumatran orangutan		class	equivalent	MHC class I protein complex	Sumatran orangutan				
+Sumatran orangutan MHC class II protein complex	Sumatran orangutan		class	equivalent	MHC class II protein complex	Sumatran orangutan				
 Xela-UAAg protein complex	Xela-UAAg		locus	equivalent	MHC class I protein complex	clawed frog	Xela-UAAg chain	Beta-2-microglobulin		
 YF1w*7.1 protein complex	YF1w*7.1	YF1*7.1	complete molecule	equivalent	non-classical MHC protein complex	chicken	YF1w*7.1 chain		YF1 haplotype	
 atlantic salmon MHC class I protein complex	atlantic salmon		class	equivalent	MHC class I protein complex	atlantic salmon				
 atlantic salmon MHC class II protein complex	atlantic salmon		class	equivalent	MHC class II protein complex	atlantic salmon				
 bighorn sheep MHC class I protein complex	bighorn sheep		class	equivalent	MHC class I protein complex	bighorn sheep				
 bighorn sheep MHC class II protein complex	bighorn sheep		class	equivalent	MHC class II protein complex	bighorn sheep				
+black crested mangabey MHC class I protein complex	black crested mangabey		class	equivalent	MHC class I protein complex	black crested mangabey				
+black crested mangabey MHC class II protein complex	black crested mangabey		class	equivalent	MHC class II protein complex	black crested mangabey				
 black flying fox MHC class I protein complex	black flying fox		class	equivalent	MHC class I protein complex	black flying fox				
+black-headed night monkey MHC class I protein complex	black-headed night monkey		class	equivalent	MHC class I protein complex	black-headed night monkey				
+black-headed night monkey MHC class II protein complex	black-headed night monkey		class	equivalent	MHC class II protein complex	black-headed night monkey				
+black-headed spider monkey MHC class I protein complex	black-headed spider monkey		class	equivalent	MHC class I protein complex	black-headed spider monkey				
+black-headed spider monkey MHC class II protein complex	black-headed spider monkey		class	equivalent	MHC class II protein complex	black-headed spider monkey				
+blue monkey MHC class I protein complex	blue monkey		class	equivalent	MHC class I protein complex	blue monkey				
+blue monkey MHC class II protein complex	blue monkey		class	equivalent	MHC class II protein complex	blue monkey				
 bonobo MHC class I protein complex	bonobo		class	equivalent	MHC class I protein complex	bonobo				
 bonobo MHC class I protein complex	bonobo		class	equivalent	MHC class I protein complex	bonobo				
 bonobo MHC class II protein complex	bonobo		class	equivalent	MHC class II protein complex	bonobo				
+brown-mantled tamarin MHC class I protein complex	brown-mantled tamarin		class	equivalent	MHC class I protein complex	brown-mantled tamarin				
+brown-mantled tamarin MHC class II protein complex	brown-mantled tamarin		class	equivalent	MHC class II protein complex	brown-mantled tamarin				
 cat MHC class I protein complex	cat		class	equivalent	MHC class I protein complex	cat				
 cat MHC class II protein complex	cat		class	equivalent	MHC class II protein complex	cat				
 cat non-classical MHC protein complex	cat		class	equivalent	non-classical MHC protein complex	cat				
@@ -24981,6 +25015,8 @@ cattle MHC class I protein complex	cattle		class	equivalent	MHC class I protein 
 cattle MHC class II protein complex	cattle		class	equivalent	MHC class II protein complex	cattle				
 cattle MR1 protein complex	cattle MR1	boMR1|cowMR1	complete molecule	equivalent	non-classical MHC protein complex	cattle	cattle MR1 chain	Beta-2-microglobulin		
 cattle non-classical MHC protein complex	cattle		class	equivalent	non-classical MHC protein complex	cattle				
+chacma Baboon MHC class I protein complex	chacma Baboon		class	equivalent	MHC class I protein complex	chacma Baboon				
+chacma Baboon MHC class II protein complex	chacma Baboon		class	equivalent	MHC class II protein complex	chacma Baboon				
 chicken CD1-1 protein complex	chicken CD1-1	cCD1-1|CD1.1	complete molecule	equivalent	non-classical MHC protein complex	chicken	chicken CD1-1 chain	Beta-2-microglobulin		
 chicken CD1-2 protein complex	chicken CD1-2	cCD1-2|CD1.2	complete molecule	equivalent	non-classical MHC protein complex	chicken	chicken CD1-2 chain	Beta-2-microglobulin		
 chicken MHC class I protein complex	chicken		class	equivalent	MHC class I protein complex	chicken				
@@ -24993,6 +25029,8 @@ chimpanzee MHC class II protein complex	chimpanzee		class	equivalent	MHC class I
 chimpanzee non-classical MHC protein complex	chimpanzee		class	equivalent	non-classical MHC protein complex	chimpanzee				
 clawed frog MHC class I protein complex	clawed frog		class	equivalent	MHC class I protein complex	clawed frog				
 clawed frog MHC class II protein complex	clawed frog		class	equivalent	MHC class II protein complex	clawed frog				
+common squirrel monkey MHC class I protein complex	common squirrel monkey		class	equivalent	MHC class I protein complex	common squirrel monkey				
+common squirrel monkey MHC class II protein complex	common squirrel monkey		class	equivalent	MHC class II protein complex	common squirrel monkey				
 cotton-top tamarin MHC class I protein complex	cotton-top tamarin		class	equivalent	MHC class I protein complex	cotton-top tamarin				
 cotton-top tamarin MHC class I protein complex	cotton-top tamarin		class	equivalent	MHC class I protein complex	cotton-top tamarin				
 cotton-top tamarin MHC class II protein complex	cotton-top tamarin		class	equivalent	MHC class II protein complex	cotton-top tamarin				
@@ -25002,16 +25040,34 @@ dog MHC class I protein complex	dog		class	equivalent	MHC class I protein comple
 dog MHC class II protein complex	dog		class	equivalent	MHC class II protein complex	dog				
 domestic sheep MHC class I protein complex	domestic sheep		class	equivalent	MHC class I protein complex	domestic sheep				
 domestic sheep MHC class II protein complex	domestic sheep		class	equivalent	MHC class II protein complex	domestic sheep				
+drill MHC class I protein complex	drill		class	equivalent	MHC class I protein complex	drill				
+drill MHC class II protein complex	drill		class	equivalent	MHC class II protein complex	drill				
 duck MHC class I protein complex	duck		class	equivalent	MHC class I protein complex	duck				
+eastern gorilla MHC class I protein complex	eastern gorilla		class	equivalent	MHC class I protein complex	eastern gorilla				
+eastern gorilla MHC class II protein complex	eastern gorilla		class	equivalent	MHC class II protein complex	eastern gorilla				
+gelada MHC class I protein complex	gelada		class	equivalent	MHC class I protein complex	gelada				
+gelada MHC class II protein complex	gelada		class	equivalent	MHC class II protein complex	gelada				
 giant panda MHC class I protein complex	giant panda		class	equivalent	MHC class I protein complex	giant panda				
 giant panda MHC class II protein complex	giant panda		class	equivalent	MHC class II protein complex	giant panda				
 goat MHC class I protein complex	goat		class	equivalent	MHC class I protein complex	goat				
 goat MHC class II protein complex	goat		class	equivalent	MHC class II protein complex	goat				
+golden lion tamarin MHC class I protein complex	golden lion tamarin		class	equivalent	MHC class I protein complex	golden lion tamarin				
+golden lion tamarin MHC class II protein complex	golden lion tamarin		class	equivalent	MHC class II protein complex	golden lion tamarin				
+golden snub-nosed monkey MHC class I protein complex	golden snub-nosed monkey		class	equivalent	MHC class I protein complex	golden snub-nosed monkey				
+golden snub-nosed monkey MHC class II protein complex	golden snub-nosed monkey		class	equivalent	MHC class II protein complex	golden snub-nosed monkey				
 gorilla MHC class I protein complex	gorilla		class	equivalent	MHC class I protein complex	gorilla				
 gorilla MHC class I protein complex	gorilla		class	equivalent	MHC class I protein complex	gorilla				
 gorilla MHC class II protein complex	gorilla		class	equivalent	MHC class II protein complex	gorilla				
 grass carp MHC class I protein complex	grass carp		class	equivalent	MHC class I protein complex	grass carp				
 grass carp MHC class II protein complex	grass carp		class	equivalent	MHC class II protein complex	grass carp				
+gray-bellied night monkey MHC class I protein complex	gray-bellied night monkey		class	equivalent	MHC class I protein complex	gray-bellied night monkey				
+gray-bellied night monkey MHC class II protein complex	gray-bellied night monkey		class	equivalent	MHC class II protein complex	gray-bellied night monkey				
+green monkey MHC class I protein complex	green monkey		class	equivalent	MHC class I protein complex	green monkey				
+green monkey MHC class II protein complex	green monkey		class	equivalent	MHC class II protein complex	green monkey				
+grivet MHC class I protein complex	grivet		class	equivalent	MHC class I protein complex	grivet				
+grivet MHC class II protein complex	grivet		class	equivalent	MHC class II protein complex	grivet				
+hamadryas baboon MHC class I protein complex	hamadryas baboon		class	equivalent	MHC class I protein complex	hamadryas baboon				
+hamadryas baboon MHC class II protein complex	hamadryas baboon		class	equivalent	MHC class II protein complex	hamadryas baboon				
 horse MHC class I protein complex	horse		class	equivalent	MHC class I protein complex	horse				
 horse MHC class II protein complex	horse		class	equivalent	MHC class II protein complex	horse				
 human BTN3A1 protein complex	human BTN3A1	Butyrophilin BTN3A1	complete molecule	equivalent	non-classical MHC protein complex	human	human BTN3A1 chain			
@@ -25023,6 +25079,14 @@ human MHC class I protein complex	human		class	equivalent	MHC class I protein co
 human MHC class II protein complex	human		class	equivalent	MHC class II protein complex	human				
 human MR1 protein complex	human MR1	HLA-MR1|hMR1	complete molecule	equivalent	non-classical MHC protein complex	human	human MR1 chain	Beta-2-microglobulin		
 human non-classical MHC protein complex	human		class	equivalent	non-classical MHC protein complex	human				
+lar gibbon MHC class I protein complex	lar gibbon		class	equivalent	MHC class I protein complex	lar gibbon				
+lar gibbon MHC class II protein complex	lar gibbon		class	equivalent	MHC class II protein complex	lar gibbon				
+lion-tailed macaque MHC class I protein complex	lion-tailed macaque		class	equivalent	MHC class I protein complex	lion-tailed macaque				
+lion-tailed macaque MHC class II protein complex	lion-tailed macaque		class	equivalent	MHC class II protein complex	lion-tailed macaque				
+mandrill MHC class I protein complex	mandrill		class	equivalent	MHC class I protein complex	mandrill				
+mandrill MHC class II protein complex	mandrill		class	equivalent	MHC class II protein complex	mandrill				
+mantled guereza MHC class I protein complex	mantled guereza		class	equivalent	MHC class I protein complex	mantled guereza				
+mantled guereza MHC class II protein complex	mantled guereza		class	equivalent	MHC class II protein complex	mantled guereza				
 marmoset MHC class I protein complex	marmoset		class	equivalent	MHC class I protein complex	marmoset				
 mouse CD1d1 protein complex	mouse CD1d1		complete molecule	equivalent	non-classical MHC protein complex	mouse	mouse CD1d1 chain	Beta-2-microglobulin		
 mouse CD1d2 protein complex	mouse CD1d2		complete molecule	equivalent	non-classical MHC protein complex	mouse	mouse CD1d2 chain	Beta-2-microglobulin		
@@ -25031,9 +25095,19 @@ mouse MHC class I protein complex	mouse		class	equivalent	MHC class I protein co
 mouse MHC class II protein complex	mouse		class	equivalent	MHC class II protein complex	mouse				
 mouse MR1 protein complex	mouse MR1	mMR1	complete molecule	equivalent	non-classical MHC protein complex	mouse	mouse MR1 chain	Beta-2-microglobulin		
 mouse non-classical MHC protein complex	mouse		class	equivalent	non-classical MHC protein complex	mouse				
+moustached tamarin MHC class I protein complex	moustached tamarin		class	equivalent	MHC class I protein complex	moustached tamarin				
+moustached tamarin MHC class II protein complex	moustached tamarin		class	equivalent	MHC class II protein complex	moustached tamarin				
 non-classical MHC protein complex	non-classical		class	subclass	MHC protein complex					
+northern pig-tailed macaque MHC class I protein complex	northern pig-tailed macaque		class	equivalent	MHC class I protein complex	northern pig-tailed macaque				
+northern pig-tailed macaque MHC class II protein complex	northern pig-tailed macaque		class	equivalent	MHC class II protein complex	northern pig-tailed macaque				
+northern plains gray langur MHC class I protein complex	northern plains gray langur		class	equivalent	MHC class I protein complex	northern plains gray langur				
+northern plains gray langur MHC class II protein complex	northern plains gray langur		class	equivalent	MHC class II protein complex	northern plains gray langur				
+olive baboon MHC class I protein complex	olive baboon		class	equivalent	MHC class I protein complex	olive baboon				
+olive baboon MHC class II protein complex	olive baboon		class	equivalent	MHC class II protein complex	olive baboon				
 pig MHC class I protein complex	pig		class	equivalent	MHC class I protein complex	pig				
 pig MHC class II protein complex	pig		class	equivalent	MHC class II protein complex	pig				
+pygmy marmoset MHC class I protein complex	pygmy marmoset		class	equivalent	MHC class I protein complex	pygmy marmoset				
+pygmy marmoset MHC class II protein complex	pygmy marmoset		class	equivalent	MHC class II protein complex	pygmy marmoset				
 rabbit MHC class I protein complex	rabbit		class	equivalent	MHC class I protein complex	rabbit				
 rabbit MHC class II protein complex	rabbit		class	equivalent	MHC class II protein complex	rabbit				
 rainbow trout MHC class I protein complex	rainbow trout		class	equivalent	MHC class I protein complex	rainbow trout				
@@ -25042,6 +25116,8 @@ rat CD1d protein complex	rat CD1d	rCD1d	complete molecule	equivalent	non-classic
 rat MHC class I protein complex	rat		class	equivalent	MHC class I protein complex	rat				
 rat MHC class II protein complex	rat		class	equivalent	MHC class II protein complex	rat				
 rat non-classical MHC protein complex	rat		class	equivalent	non-classical MHC protein complex	rat				
+red-bellied titi MHC class I protein complex	red-bellied titi		class	equivalent	MHC class I protein complex	red-bellied titi				
+red-bellied titi MHC class II protein complex	red-bellied titi		class	equivalent	MHC class II protein complex	red-bellied titi				
 rhesus macaque CD1b protein complex	rhesus macaque CD1b	Mamu CD1b	complete molecule	equivalent	non-classical MHC protein complex	rhesus macaque	rhesus macaque CD1b chain	Beta-2-microglobulin		
 rhesus macaque CD1c protein complex	rhesus macaque CD1c	Mamu CD1c	complete molecule	equivalent	non-classical MHC protein complex	rhesus macaque	rhesus macaque CD1c chain	Beta-2-microglobulin		
 rhesus macaque MHC class I protein complex	rhesus macaque		class	equivalent	MHC class I protein complex	rhesus macaque				
@@ -25050,3 +25126,25 @@ rhesus macaque MHC class II protein complex	rhesus macaque		class	equivalent	MHC
 rhesus macaque MHC class II protein complex	rhesus macaque		class	equivalent	MHC class II protein complex	rhesus macaque				
 rhesus macaque MR1 protein complex	rhesus macaque MR1		complete molecule	equivalent	non-classical MHC protein complex	rhesus macaque	rhesus macaque MR1 chain	Beta-2-microglobulin		
 rhesus macaque non-classical MHC protein complex	rhesus macaque		class	equivalent	non-classical MHC protein complex	rhesus macaque				
+silvery Javan gibbon MHC class I protein complex	silvery Javan gibbon		class	equivalent	MHC class I protein complex	silvery Javan gibbon				
+silvery Javan gibbon MHC class II protein complex	silvery Javan gibbon		class	equivalent	MHC class II protein complex	silvery Javan gibbon				
+sooty mangabey MHC class I protein complex	sooty mangabey		class	equivalent	MHC class I protein complex	sooty mangabey				
+sooty mangabey MHC class II protein complex	sooty mangabey		class	equivalent	MHC class II protein complex	sooty mangabey				
+southern pig-tailed macaque MHC class I protein complex	southern pig-tailed macaque		class	equivalent	MHC class I protein complex	southern pig-tailed macaque				
+southern pig-tailed macaque MHC class II protein complex	southern pig-tailed macaque		class	equivalent	MHC class II protein complex	southern pig-tailed macaque				
+stump-tailed macaque MHC class I protein complex	stump-tailed macaque		class	equivalent	MHC class I protein complex	stump-tailed macaque				
+stump-tailed macaque MHC class II protein complex	stump-tailed macaque		class	equivalent	MHC class II protein complex	stump-tailed macaque				
+three-striped night monkey MHC class I protein complex	three-striped night monkey		class	equivalent	MHC class I protein complex	three-striped night monkey				
+three-striped night monkey MHC class II protein complex	three-striped night monkey		class	equivalent	MHC class II protein complex	three-striped night monkey				
+tufted capuchin MHC class I protein complex	tufted capuchin		class	equivalent	MHC class I protein complex	tufted capuchin				
+tufted capuchin MHC class II protein complex	tufted capuchin		class	equivalent	MHC class II protein complex	tufted capuchin				
+vervet monkey MHC class I protein complex	vervet monkey		class	equivalent	MHC class I protein complex	vervet monkey				
+vervet monkey MHC class II protein complex	vervet monkey		class	equivalent	MHC class II protein complex	vervet monkey				
+white-faced saki MHC class I protein complex	white-faced saki		class	equivalent	MHC class I protein complex	white-faced saki				
+white-faced saki MHC class II protein complex	white-faced saki		class	equivalent	MHC class II protein complex	white-faced saki				
+white-fronted spider monkey MHC class I protein complex	white-fronted spider monkey		class	equivalent	MHC class I protein complex	white-fronted spider monkey				
+white-fronted spider monkey MHC class II protein complex	white-fronted spider monkey		class	equivalent	MHC class II protein complex	white-fronted spider monkey				
+white-lipped tamarin MHC class I protein complex	white-lipped tamarin		class	equivalent	MHC class I protein complex	white-lipped tamarin				
+white-lipped tamarin MHC class II protein complex	white-lipped tamarin		class	equivalent	MHC class II protein complex	white-lipped tamarin				
+yellow baboon MHC class I protein complex	yellow baboon		class	equivalent	MHC class I protein complex	yellow baboon				
+yellow baboon MHC class II protein complex	yellow baboon		class	equivalent	MHC class II protein complex	yellow baboon				

--- a/src/scripts/replace_labels.py
+++ b/src/scripts/replace_labels.py
@@ -1,0 +1,61 @@
+import csv
+import os
+
+from argparse import ArgumentParser, FileType
+
+
+def main():
+	parser = ArgumentParser()
+	parser.add_argument("source", type=FileType("r"))
+	parser.add_argument("target", type=FileType("w"))
+	args = parser.parse_args()
+
+	# Get a map of label to ID for all MRO & external terms
+	label_id = {}
+	with open("index.tsv", "r") as f:
+		reader = csv.reader(f, delimiter="\t")
+		next(reader)
+		next(reader)
+		for row in reader:
+			label_id[row[1]] = row[0]
+	with open("ontology/external.tsv", "r") as f:
+		reader = csv.reader(f, delimiter="\t")
+		next(reader)
+		next(reader)
+		for row in reader:
+			label_id[row[1]] = row[0]
+
+	# Replace any labels with single quotes with their IDs
+	# Only check for cells in "C" template string columns
+	rows = []
+	reader = csv.DictReader(args.source, delimiter="\t")
+	headers = reader.fieldnames
+	if None in headers:
+		# Extra tab may have been added to the sheet, clean it out
+		headers.remove(None)
+	robot_strings = next(reader)
+	rows.append(robot_strings)
+	check_headers = [x for x, y in robot_strings.items() if y.startswith("C ")]
+	for row in reader:
+		for ch in check_headers:
+			value = row[ch]
+			if value.startswith("("):
+				continue
+			if "'" in value:
+				term_id = label_id.get(value)
+				if not term_id:
+					print(f"ERROR: Cannot find ID for '{value}'")
+				else:
+					row[ch] = term_id
+		if None in row:
+			# Extra tab may have been added to the sheet, clean it out
+			del row[None]
+		rows.append(row)
+
+	writer = csv.DictWriter(args.target, delimiter="\t", lineterminator="\n", fieldnames=headers)
+	writer.writeheader()
+	writer.writerows(rows)
+
+
+if __name__ == '__main__':
+	main()

--- a/src/scripts/validation/validate_templates.py
+++ b/src/scripts/validation/validate_templates.py
@@ -1163,7 +1163,7 @@ def main():
                 "level",
                 "rule ID",
                 "rule",
-                "suggestion",
+                "value",
                 "message",
             ],
             delimiter="\t",


### PR DESCRIPTION
This PR contains 294 new MRO terms. They are the "MHC class I" and "MHC class II" locus, chain, and protein complex terms for 49 new NCBI taxon in `external.tsv`.

6 of these taxon terms contain a single quote, which breaks `robot template`. As a workaround, I've included a new script to replace usages with their IDs. Originally I was planning to use `sed` and just replace the NCBITaxon terms, but the MRO terms are also referenced in places so we needed to be a little smarter about it (e.g., "Azara's night monkey MHC class I locus"). This will allow Randi to add more terms with single quotes in the future without it being an issue.