### PR TITLE
2021-07-22 update

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -18333,12 +18333,12 @@ BoLA-2*016:01 protein complex	18425	2
 BoLA-DRB3*020:04 protein complex	18426	DRB3		
 BoLA-DQA*012:04 protein complex	18427	DQ		
 Aime-128 protein complex	18428	128		
-Ctid-UAA b2m-1-II protein complex	18429	UAA		
+Ctid-UAA/b2m-1-II protein complex	18429	UAA		
 Mafa-A1*063:01 protein complex	18430	A1		
 Mafa-A1 protein complex	18431	A1		
 crab-eating macaque MHC class I protein complex	18432			
 crab-eating macaque MHC class II protein complex	18433			
-Ctid-UAA b2m-2 protein complex	18434			
+Ctid-UAA/b2m-2 protein complex	18434			
 Anpl-UAA*SD protein complex	18435	UAA		
 rhesus macaque CD1b protein complex	18436	CD1		
 rhesus macaque CD1c protein complex	18437	CD1		
@@ -20340,3 +20340,4 @@ HLA-DQA1*02:01/DQB1*06:02 protein complex	20432	DQ
 chicken MHC class II protein complex with B2 haplotype	20433			
 chicken MHC class II protein complex with BF2 haplotype	20434			
 HLA-DQA1*05:01/DQB1*02:02 protein complex	20435	DQ		
+HLA-DPA1*01:03/DPB1*10:01 protein complex	20436	DP	300693	

--- a/index.tsv
+++ b/index.tsv
@@ -37013,7 +37013,7 @@ MRO:0037009	HLA-C*12:139 chain	owl:Class
 MRO:0037010	HLA-B*07:44 chain	owl:Class	
 MRO:0037011	HLA-C*03:23 chain	owl:Class	
 MRO:0037012	Aime-128 protein complex	owl:Class	
-MRO:0037013	Ctid-UAA b2m-1-II protein complex	owl:Class	
+MRO:0037013	Ctid-UAA/b2m-1-II protein complex	owl:Class	
 MRO:0037014	HLA-A*01:159 protein complex	owl:Class	
 MRO:0037015	HLA-A*01:281 protein complex	owl:Class	
 MRO:0037016	HLA-A*02:437 protein complex	owl:Class	
@@ -37053,7 +37053,7 @@ MRO:0037049	Beta-2-microglobulin locus	owl:Class
 MRO:0037050	grass carp Beta-2-microglobulin-1-II chain	owl:Class	
 MRO:0037051	grass carp Beta-2-microglobulin-2 chain	owl:Class	
 MRO:0037052	grass carp Beta-2-microglobulin chain	owl:Class	
-MRO:0037053	Ctid-UAA b2m-2 protein complex	owl:Class	
+MRO:0037053	Ctid-UAA/b2m-2 protein complex	owl:Class	
 MRO:0037054	Anpl-UAA*SD protein complex	owl:Class	
 MRO:0037055	Anpl-UAA*SD chain	owl:Class	
 MRO:0037056	Mamu-CD1 locus	owl:Class	
@@ -46249,3 +46249,6 @@ MRO:0046247	northern plains gray langur MHC class I protein complex	owl:Class
 MRO:0046248	northern plains gray langur MHC class II protein complex	owl:Class	
 MRO:0046249	gelada MHC class I protein complex	owl:Class	
 MRO:0046250	gelada MHC class II protein complex	owl:Class	
+MRO:0046251	human Beta-2-microglobulin chain	owl:Class	
+MRO:0046252	H2-Db/human Beta-2-microglobulin protein complex	owl:Class	
+MRO:0046253	human Beta-2-microglobulin locus	owl:Class	

--- a/ontology/chain.tsv
+++ b/ontology/chain.tsv
@@ -20134,6 +20134,7 @@ hamadryas baboon MHC class II chain		equivalent	protein	hamadryas baboon MHC cla
 horse MHC class I chain		equivalent	protein	horse MHC class I locus	
 horse MHC class II chain		equivalent	protein	horse MHC class II locus	
 human BTN3A1 chain		subclass	HLA-BTN3A chain		
+human Beta-2-microglobulin chain		equivalent	protein	human Beta-2-microglobulin locus	
 human CD1a chain		subclass	HLA-CD1 chain		
 human CD1b chain		subclass	HLA-CD1 chain		
 human CD1c chain		subclass	HLA-CD1 chain		

--- a/ontology/genetic-locus.tsv
+++ b/ontology/genetic-locus.tsv
@@ -204,6 +204,7 @@ hamadryas baboon MHC class I locus		subclass	MHC class I locus	hamadryas baboon
 hamadryas baboon MHC class II locus		subclass	MHC class II locus	hamadryas baboon
 horse MHC class I locus		subclass	MHC class I locus	horse
 horse MHC class II locus		subclass	MHC class II locus	horse
+human Beta-2-microglobulin locus		subclass	Beta-2-microglobulin locus	human
 human MHC class I locus		subclass	MHC class I locus	human
 human MHC class II locus		subclass	MHC class II locus	human
 human non-classical MHC locus		subclass	non-classical MHC locus	human

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -1,5 +1,6 @@
 Label	IEDB Label	Synonyms	Restriction Level	Class Type	Parent	In Taxon	Alpha Chain	Beta Chain	With Haplotype	With Serotype
 LABEL	A OBI:9991118	A IAO:0000118 SPLIT=|	A has MHC restriction level	CLASS_TYPE	C %	C 'in taxon' some %	C 'has part' some %	C 'has part' some %	C 'haplotype member of' some %	C 'serotype member of' some %
+										
 Aime-128 protein complex	Aime-128		locus	equivalent	MHC class I protein complex	giant panda	Aime-128 chain	Beta-2-microglobulin		
 Anpl-UAA protein complex	Anpl-UAA		locus	equivalent	MHC class I protein complex	duck	Anpl-UAA chain	Beta-2-microglobulin		
 Anpl-UAA*01 protein complex	Anpl-UAA*01		complete molecule	equivalent	MHC class I protein complex	duck	Anpl-UAA*01 chain	Beta-2-microglobulin		
@@ -705,8 +706,8 @@ Bornean orangutan MHC class I protein complex	Bornean orangutan		class	equivalen
 Bornean orangutan MHC class II protein complex	Bornean orangutan		class	equivalent	MHC class II protein complex	Bornean orangutan				
 Caja-E protein complex	Caja-E		locus	equivalent	MHC class I protein complex	marmoset	Caja-E chain	Beta-2-microglobulin		
 Caja-G protein complex	Caja-G		locus	equivalent	MHC class I protein complex	marmoset	Caja-G chain	Beta-2-microglobulin		
-Ctid-UAA b2m-1-II protein complex	Ctid-UAA b2m-1-II		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-1-II chain		
-Ctid-UAA b2m-2 protein complex	Ctid-UAA b2m-2		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-2 chain		
+Ctid-UAA/b2m-1-II protein complex	Ctid-UAA/b2m-1-II		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-1-II chain		
+Ctid-UAA/b2m-2 protein complex	Ctid-UAA/b2m-2		locus	equivalent	MHC class I protein complex	grass carp	Ctid-UAA chain	grass carp Beta-2-microglobulin-2 chain		
 DLA-88 protein complex	DLA-88		locus	equivalent	MHC class I protein complex	dog	DLA-88 chain	Beta-2-microglobulin		
 DLA-88*034:01 protein complex	DLA-88*034:01		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*034:01 chain	Beta-2-microglobulin		
 DLA-88*501:01 protein complex	DLA-88*501:01		complete molecule	equivalent	MHC class I protein complex	dog	DLA-88*501:01 chain	Beta-2-microglobulin		
@@ -742,6 +743,7 @@ Guinea baboon MHC class I protein complex	Guinea baboon		class	equivalent	MHC cl
 Guinea baboon MHC class II protein complex	Guinea baboon		class	equivalent	MHC class II protein complex	Guinea baboon				
 H2-D protein complex	H2-D		locus	equivalent	MHC class I protein complex	mouse	H2-D chain	Beta-2-microglobulin		
 H2-Db protein complex	H2-Db		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Db chain	Beta-2-microglobulin	H2-b haplotype	
+H2-Db/human Beta-2-microglobulin protein complex	H2-Db/huB2m		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Db chain	human Beta-2-microglobulin chain	H2-b haplotype	
 H2-Dd protein complex	H2-Dd		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Dd chain	Beta-2-microglobulin	H2-d haplotype	
 H2-Dk protein complex	H2-Dk		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Dk chain	Beta-2-microglobulin	H2-k haplotype	
 H2-Dq protein complex	H2-Dq		complete molecule	equivalent	MHC class I protein complex	mouse	H2-Dq chain	Beta-2-microglobulin	H2-q haplotype	
@@ -12928,7 +12930,6 @@ HLA-DPA1*01:03/DPB1*05:01 protein complex	HLA-DPA1*01:03/DPB1*05:01		complete mo
 HLA-DPA1*01:03/DPB1*06:01 protein complex	HLA-DPA1*01:03/DPB1*06:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*06:01 chain		HLA-DPw6 serotype
 HLA-DPA1*01:03/DPB1*08:01 protein complex	HLA-DPA1*01:03/DPB1*08:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*08:01 chain		
 HLA-DPA1*01:03/DPB1*09:01 protein complex	HLA-DPA1*01:03/DPB1*09:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*09:01 chain		
-HLA-DPA1*01:03/DPB1*10:01 protein complex	HLA-DPA1*01:03/DPB1*10:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*10:01 chain		
 HLA-DPA1*01:03/DPB1*11:01 protein complex	HLA-DPA1*01:03/DPB1*11:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*11:01 chain		
 HLA-DPA1*01:03/DPB1*13:01 protein complex	HLA-DPA1*01:03/DPB1*13:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*13:01 chain		
 HLA-DPA1*01:03/DPB1*14:01 protein complex	HLA-DPA1*01:03/DPB1*14:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*14:01 chain		

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -1,6 +1,5 @@
 Label	IEDB Label	Synonyms	Restriction Level	Class Type	Parent	In Taxon	Alpha Chain	Beta Chain	With Haplotype	With Serotype
 LABEL	A OBI:9991118	A IAO:0000118 SPLIT=|	A has MHC restriction level	CLASS_TYPE	C %	C 'in taxon' some %	C 'has part' some %	C 'has part' some %	C 'haplotype member of' some %	C 'serotype member of' some %
-										
 Aime-128 protein complex	Aime-128		locus	equivalent	MHC class I protein complex	giant panda	Aime-128 chain	Beta-2-microglobulin		
 Anpl-UAA protein complex	Anpl-UAA		locus	equivalent	MHC class I protein complex	duck	Anpl-UAA chain	Beta-2-microglobulin		
 Anpl-UAA*01 protein complex	Anpl-UAA*01		complete molecule	equivalent	MHC class I protein complex	duck	Anpl-UAA*01 chain	Beta-2-microglobulin		

--- a/ontology/molecule.tsv
+++ b/ontology/molecule.tsv
@@ -12929,6 +12929,7 @@ HLA-DPA1*01:03/DPB1*05:01 protein complex	HLA-DPA1*01:03/DPB1*05:01		complete mo
 HLA-DPA1*01:03/DPB1*06:01 protein complex	HLA-DPA1*01:03/DPB1*06:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*06:01 chain		HLA-DPw6 serotype
 HLA-DPA1*01:03/DPB1*08:01 protein complex	HLA-DPA1*01:03/DPB1*08:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*08:01 chain		
 HLA-DPA1*01:03/DPB1*09:01 protein complex	HLA-DPA1*01:03/DPB1*09:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*09:01 chain		
+HLA-DPA1*01:03/DPB1*10:01 protein complex	HLA-DPA1*01:03/DPB1*10:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*10:01 chain		
 HLA-DPA1*01:03/DPB1*11:01 protein complex	HLA-DPA1*01:03/DPB1*11:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*11:01 chain		
 HLA-DPA1*01:03/DPB1*13:01 protein complex	HLA-DPA1*01:03/DPB1*13:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*13:01 chain		
 HLA-DPA1*01:03/DPB1*14:01 protein complex	HLA-DPA1*01:03/DPB1*14:01		complete molecule	equivalent	MHC class II protein complex	human	HLA-DPA1*01:03 chain	HLA-DPB1*14:01 chain		


### PR DESCRIPTION
Updates:
* One term added to IEDB tab (HLA-DPA1\*01:03/DPB1\*10:01 protein complex)
* Fixed labels for two terms to include "/"

And three new terms:
ID | Label
--- | ---
MRO:0046251 | human Beta-2-microglobulin chain
MRO:0046252 | H2-Db/human Beta-2-microglobulin protein complex
MRO:0046253 | human Beta-2-microglobulin locus