### PR TITLE
Add script to add chain accessions for IEDB terms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,8 +289,12 @@ IEDB_TARGETS := build/mro-iedb.owl \
                 build/ALLELE_FINDER_SEARCH.csv \
                 build/ALLELE_FINDER_TREE.csv
 
+# add chain_i and chain_ii accessions to IEDB sheet
+build/iedb.tsv: src/scripts/add_chain_accessions.py iedb/iedb.tsv ontology/molecule.tsv ontology/chain-sequence.tsv
+	python3 $^ $@
+
 # extended version for IEDB use
-build/mro-iedb.owl: mro.owl iedb/iedb.tsv iedb/iedb-manual.tsv | build/robot.jar iedb
+build/mro-iedb.owl: mro.owl build/iedb.tsv iedb/iedb-manual.tsv | build/robot.jar iedb
 	$(ROBOT) template \
 	--prefix "MRO: $(OBO)/MRO_" \
 	--input $< \

--- a/src/queries/mhc_allele_restriction.rq
+++ b/src/queries/mhc_allele_restriction.rq
@@ -26,6 +26,8 @@ SELECT ?mhc_allele_restriction_id
   ?chain_ii_mutation
   ?chain_i_source_id
   ?chain_ii_source_id
+  ?chain_i_accession
+  ?chain_ii_accession
 
 WHERE {
   ?iri
@@ -244,6 +246,12 @@ WHERE {
         rdf:rest / rdf:first / owl:someValuesFrom / rdfs:label
           ?chain_ii_locus .
   }
+  OPTIONAL {
+    ?iri MRO:has-chain-i-accession ?chain_i_accession .
+  }
+  OPTIONAL {
+    ?iri MRO:has-chain-ii-accession ?chain_ii_accession .
+  }
 }
 GROUP BY ?mhc_allele_restriction_id
   ?iri
@@ -265,4 +273,6 @@ GROUP BY ?mhc_allele_restriction_id
   ?chain_ii_mutation
   ?chain_i_source_id
   ?chain_ii_source_id
+  ?chain_i_accession
+  ?chain_ii_accession
 ORDER BY xsd:integer(?mhc_allele_restriction_id) ?synonym

--- a/src/scripts/add_chain_accessions.py
+++ b/src/scripts/add_chain_accessions.py
@@ -1,0 +1,55 @@
+import csv
+
+from argparse import ArgumentParser, FileType
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("iedb", type=FileType("r"))
+    parser.add_argument("molecule", type=FileType("r"))
+    parser.add_argument("chain_sequence", type=FileType("r"))
+    parser.add_argument("output", type=FileType("w"))
+    args = parser.parse_args()
+
+    chain_accessions = {}
+    reader = csv.DictReader(args.chain_sequence, delimiter="\t")
+    next(reader)
+    for row in reader:
+        if row["Source"] != "IMGT/HLA":
+            continue
+        chain_accessions[row["Label"]] = row["Accession"]
+
+    molecules = {}
+    reader = csv.DictReader(args.molecule, delimiter="\t")
+    next(reader)
+    for row in reader:
+        chain_i_label = row["Alpha Chain"]
+        chain_i_acc = None
+        if chain_i_label:
+            chain_i_acc = chain_accessions.get(chain_i_label)
+        chain_ii_label = row["Beta Chain"]
+        chain_ii_acc = None
+        if chain_ii_label:
+            chain_ii_acc = chain_accessions.get(chain_ii_label)
+        molecules[row["Label"]] = {"chain_i": chain_i_acc, "chain_ii": chain_ii_acc}
+
+    rows = []
+    reader = csv.DictReader(args.iedb, delimiter="\t")
+    row = next(reader)
+    row["Chain I Accession"] = "A MRO:has-chain-i-accession"
+    row["Chain II Accession"] = "A MRO:has-chain-ii-accession"
+    rows.append(row)
+    for row in reader:
+        label = row["Label"]
+        if label in molecules:
+            row["Chain I Accession"] = molecules[label]["chain_i"]
+            row["Chain II Accession"] = molecules[label]["chain_ii"]
+        rows.append(row)
+
+    writer = csv.DictWriter(args.output, fieldnames=["Label", "IEDB ID", "Locus", "Chain I Source ID", "Chain I Accession", "Chain II Source ID", "Chain II Accession"], delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/scripts/add_chain_accessions.py
+++ b/src/scripts/add_chain_accessions.py
@@ -46,10 +46,23 @@ def main():
             row["Chain II Accession"] = molecules[label]["chain_ii"]
         rows.append(row)
 
-    writer = csv.DictWriter(args.output, fieldnames=["Label", "IEDB ID", "Locus", "Chain I Source ID", "Chain I Accession", "Chain II Source ID", "Chain II Accession"], delimiter="\t", lineterminator="\n")
+    writer = csv.DictWriter(
+        args.output,
+        fieldnames=[
+            "Label",
+            "IEDB ID",
+            "Locus",
+            "Chain I Source ID",
+            "Chain I Accession",
+            "Chain II Source ID",
+            "Chain II Accession",
+        ],
+        delimiter="\t",
+        lineterminator="\n",
+    )
     writer.writeheader()
     writer.writerows(rows)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/scripts/validation/validate_mhc_allele_restriction.py
+++ b/src/scripts/validation/validate_mhc_allele_restriction.py
@@ -55,6 +55,8 @@ def main():
         "chain_ii_mutation": {TYPE: "string", MAX_LEN: 35, NULL: True},
         "chain_i_source_id": {TYPE: "number", NULL: True},
         "chain_ii_source_id": {TYPE: "number", NULL: True},
+        "chain_i_accession": {TYPE: "string", RE: r"HLA[0-9]+", NULL: True},
+        "chain_ii_accession": {TYPE: "string", RE: r"HLA[0-9]+", NULL: True},
         "iri": {
             TYPE: "string",
             MAX_LEN: 100,


### PR DESCRIPTION
Get the chain accessions from chain-sequence for IMGT/HLA terms only. These are added as two new columns in the `mhc_allele_restriction` TSV for IEDB - `chain_i_accession` and `chain_ii_accession`.