### PR TITLE
2021-12-15_update

### DIFF
--- a/iedb/iedb.tsv
+++ b/iedb/iedb.tsv
@@ -22664,3 +22664,4 @@ common brushtail MHC class I protein complex	22756
 common brushtail MHC class II protein complex	22757			
 Trvu-UB*01:01 protein complex	22758	UB		
 HLA-DQA1*03:01/DQB1*06:04 protein complex	22759	DQ		
+HLA-DPA1*02:01/DPB1*16:01 protein complex	22760	DP		


### PR DESCRIPTION
adds one row to iedb tab:
HLA-DPA1*02:01/DPB1*16:01 protein complex
this term already existed in` index.tsv `and `molecule.tsv`, but was not yet in `iedb.tsv`.