### PR TITLE
Add MRO IDs for chains to IEDB table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ IEDB_TARGETS := build/mro-iedb.owl \
                 build/ALLELE_FINDER_TREE.csv
 
 # add chain_i and chain_ii accessions to IEDB sheet
-build/iedb.tsv: src/scripts/add_chain_accessions.py iedb/iedb.tsv ontology/molecule.tsv ontology/chain-sequence.tsv
+build/iedb.tsv: src/scripts/add_chain_accessions.py index.tsv iedb/iedb.tsv ontology/molecule.tsv ontology/chain-sequence.tsv
 	python3 $^ $@
 
 # extended version for IEDB use

--- a/src/queries/mhc_allele_restriction.rq
+++ b/src/queries/mhc_allele_restriction.rq
@@ -28,6 +28,8 @@ SELECT ?mhc_allele_restriction_id
   ?chain_ii_source_id
   ?chain_i_accession
   ?chain_ii_accession
+  ?chain_i_mro_id
+  ?chain_ii_mro_id
 
 WHERE {
   ?iri
@@ -247,10 +249,12 @@ WHERE {
           ?chain_ii_locus .
   }
   OPTIONAL {
-    ?iri MRO:has-chain-i-accession ?chain_i_accession .
+    ?iri MRO:has-chain-i-accession ?chain_i_accession ;
+         MRO:has-chain-i-id ?chain_i_mro_id .
   }
   OPTIONAL {
-    ?iri MRO:has-chain-ii-accession ?chain_ii_accession .
+    ?iri MRO:has-chain-ii-accession ?chain_ii_accession ;
+         MRO:has-chain-ii-id ?chain_ii_mro_id .
   }
 }
 GROUP BY ?mhc_allele_restriction_id
@@ -275,4 +279,6 @@ GROUP BY ?mhc_allele_restriction_id
   ?chain_ii_source_id
   ?chain_i_accession
   ?chain_ii_accession
+  ?chain_i_mro_id
+  ?chain_ii_mro_id
 ORDER BY xsd:integer(?mhc_allele_restriction_id) ?synonym

--- a/src/scripts/add_chain_accessions.py
+++ b/src/scripts/add_chain_accessions.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser, FileType
 
 def main():
     parser = ArgumentParser()
+    parser.add_argument("index", type=FileType("r"))
     parser.add_argument("iedb", type=FileType("r"))
     parser.add_argument("molecule", type=FileType("r"))
     parser.add_argument("chain_sequence", type=FileType("r"))
@@ -19,31 +20,47 @@ def main():
             continue
         chain_accessions[row["Label"]] = row["Accession"]
 
+    label_to_id = {}
+    reader = csv.DictReader(args.index, delimiter="\t")
+    next(reader)
+    for row in reader:
+        if row["Label"] not in chain_accessions:
+            continue
+        label_to_id[row["Label"]] = row["ID"]
+
     molecules = {}
     reader = csv.DictReader(args.molecule, delimiter="\t")
     next(reader)
     for row in reader:
         chain_i_label = row["Alpha Chain"]
         chain_i_acc = None
+        chain_i_id = None
         if chain_i_label:
             chain_i_acc = chain_accessions.get(chain_i_label)
+            chain_i_id = label_to_id.get(chain_i_label)
         chain_ii_label = row["Beta Chain"]
         chain_ii_acc = None
+        chain_ii_id = None
         if chain_ii_label:
             chain_ii_acc = chain_accessions.get(chain_ii_label)
-        molecules[row["Label"]] = {"chain_i": chain_i_acc, "chain_ii": chain_ii_acc}
+            chain_ii_id = label_to_id.get(chain_ii_label)
+        molecules[row["Label"]] = {"chain_i_acc": chain_i_acc, "chain_i_id": chain_i_id, "chain_ii_acc": chain_ii_acc, "chain_ii_id": chain_ii_id}
 
     rows = []
     reader = csv.DictReader(args.iedb, delimiter="\t")
     row = next(reader)
     row["Chain I Accession"] = "A MRO:has-chain-i-accession"
+    row["Chain I MRO ID"] = "A MRO:has-chain-i-id"
     row["Chain II Accession"] = "A MRO:has-chain-ii-accession"
+    row["Chain II MRO ID"] = "A MRO:has-chain-ii-id"
     rows.append(row)
     for row in reader:
         label = row["Label"]
         if label in molecules:
-            row["Chain I Accession"] = molecules[label]["chain_i"]
-            row["Chain II Accession"] = molecules[label]["chain_ii"]
+            row["Chain I Accession"] = molecules[label]["chain_i_acc"]
+            row["Chain I MRO ID"] = molecules[label]["chain_i_id"]
+            row["Chain II Accession"] = molecules[label]["chain_ii_acc"]
+            row["Chain II MRO ID"] = molecules[label]["chain_ii_id"]
         rows.append(row)
 
     writer = csv.DictWriter(
@@ -54,8 +71,10 @@ def main():
             "Locus",
             "Chain I Source ID",
             "Chain I Accession",
+            "Chain I MRO ID",
             "Chain II Source ID",
             "Chain II Accession",
+            "Chain II MRO ID",
         ],
         delimiter="\t",
         lineterminator="\n",

--- a/src/scripts/validation/validate_mhc_allele_restriction.py
+++ b/src/scripts/validation/validate_mhc_allele_restriction.py
@@ -57,6 +57,8 @@ def main():
         "chain_ii_source_id": {TYPE: "number", NULL: True},
         "chain_i_accession": {TYPE: "string", RE: r"HLA[0-9]+", NULL: True},
         "chain_ii_accession": {TYPE: "string", RE: r"HLA[0-9]+", NULL: True},
+        "chain_i_mro_id": {TYPE: "string", RE: r"MRO:[0-9]{7}", NULL: True},
+        "chain_ii_mro_id": {TYPE: "string", RE: r"MRO:[0-9]{7}", NULL: True},
         "iri": {
             TYPE: "string",
             MAX_LEN: 100,


### PR DESCRIPTION
Add `chain_i_mro_id` and `chain_ii_mro_id` (corresponding to the chain accessions) to the table for IEDB. Jason has already checked the files and loaded them to IEDB, so the columns and the data are good to go.